### PR TITLE
Add relative Consumption Loss Variable and Plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.141.0
+Version: 36.142.0
 Date: 2019-10-22
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
@@ -42,5 +42,5 @@ RoxygenNote: 6.1.1
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6574409310
+ValidationKey: 6574591220
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.140.0
+Version: 36.141.0
 Date: 2019-10-22
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
@@ -42,5 +42,5 @@ RoxygenNote: 6.1.1
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6574227400
+ValidationKey: 6574409310
 VignetteBuilder: knitr

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -704,13 +704,43 @@ compareScenarios <- function(mif, hist,
   if("Policy Cost|Consumption Loss (billion US$2005/yr)" %in% magclass::getNames(data,dim=3)) {
     ## ---- Policy Cost|Consumption Loss ----
     swlatex(sw,"\\subsection{Policy Costs}")
-    p <- mipLineHistorical(data[mainReg,,"Policy Cost|Consumption Loss (billion US$2005/yr)"],x_hist=NULL,
-                           ylab='Policy Cost|Consumption Loss [billion US$2005/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"))
+
+    p <- mipLineHistorical(
+      data[mainReg,,"Policy Cost|Consumption Loss (billion US$2005/yr)"],
+      x_hist=NULL,
+      ylab='Policy Cost|Consumption Loss [billion US$2005/yr]',
+      scales="free_y",
+      plot.priority=c("x_hist","x","x_proj"))
     swfigure(sw,print,p,sw_option="height=8,width=8")
-    p <- mipLineHistorical(data[,,"Policy Cost|Consumption Loss (billion US$2005/yr)"][mainReg,,,invert=TRUE],x_hist=NULL,
-                           ylab='Policy Cost|Consumption Loss [billion US$2005/yr]',scales="free_y",plot.priority=c("x_hist","x","x_proj"),facet.ncol=3)
+
+    p <- mipLineHistorical(
+      data[,,"Policy Cost|Consumption Loss (billion US$2005/yr)"][
+        mainReg,,,invert=TRUE],
+      x_hist=NULL,
+      ylab='Policy Cost|Consumption Loss [billion US$2005/yr]',
+      scales="free_y",
+      plot.priority=c("x_hist","x","x_proj"),
+      facet.ncol=3)
     swfigure(sw,print,p,sw_option="height=9,width=8")
-  }
+
+    p <- mipLineHistorical(
+      data[mainReg,,"Policy Cost|Consumption Loss|Relative to Reference Consumption (percent)"],
+      x_hist=NULL,
+      ylab='Policy Cost|Consumption Loss|Relative to Reference Consumption [%]',
+      scales="free_y",
+      plot.priority=c("x_hist","x","x_proj"))
+    swfigure(sw,print,p,sw_option="height=9,width=8")
+
+    p <- mipLineHistorical(
+      data[,,"Policy Cost|Consumption Loss|Relative to Reference Consumption (percent)"][
+        mainReg,,,invert=TRUE],
+      x_hist=NULL,
+      ylab='Policy Cost|Consumption Loss|Relative to Reference Consumption [%]',
+      scales="free_y",
+      plot.priority=c("x_hist","x","x_proj"),
+      facet.ncol=3)
+    swfigure(sw,print,p,sw_option="height=9,width=8")
+}
 
   ## ---- Mitigation Indicators of demand-side transformation in 2050 ----
   ##varis <- c("FE|Industry (EJ/yr)",

--- a/R/reportPolicyCosts.R
+++ b/R/reportPolicyCosts.R
@@ -80,6 +80,7 @@ reportPolicyCosts <- function(gdx,gdx_ref,regionSubsetList=NULL){
   ####### calculate reporting parameters ############
   tmp <- NULL 
   tmp <- mbind(tmp,setNames((cons_bau - cons) * 1000, "Policy Cost|Consumption Loss (billion US$2005/yr)" ))
+  tmp <- mbind(tmp,setNames((cons_bau - cons)/(cons_bau + 1e-10) * 100, "Policy Cost|Consumption Loss|Relative to Reference Consumption (percent)")) 
   tmp <- mbind(tmp,setNames((gdp_bau - gdp) * 1000, "Policy Cost|GDP Loss (billion US$2005/yr)" ))
   tmp <- mbind(tmp,setNames((v_costfu +v_costin + v_costom  - (v_costfu_bau + v_costin_bau + v_costom_bau)) * 1000, "Policy Cost|Additional Total Energy System Cost (billion US$2005/yr)" ))
   # Policy costs calculated as consumption losses net the effect of climate-policy induced changes in the current account  


### PR DESCRIPTION
- Adds the variable `Policy Cost|Consumption Loss|Relative to Reference Consumption (percent)` to the reporting as suggested by Robert.
- Adds a plot of this variable to the `compareScenarios` script.