### PR TITLE
Improve Transport Sector Fuel Reporting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.154.2
-Date: 2020-02-26
+Version: 36.154.3
+Date: 2020-03-02
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -43,5 +43,5 @@ RoxygenNote: 7.0.2
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6622726356
+ValidationKey: 6624552389
 VignetteBuilder: knitr

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -101,17 +101,21 @@ reportCrossVariables <- function(gdx,output=NULL,regionSubsetList=NULL){
                  * output[r,,"PE|Biomass|Energy Crops (EJ/yr)"]
                  / output[r,,"PE|+|Biomass (EJ/yr)"],                     "SE|Liquids|Biomass|Energy Crops (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
-                   output[r,,"FE|Transport|Freight (EJ/yr)"] 
+                   output[r,,"FE|Transport|Freight|Liquids (EJ/yr)"]
                  * output[r,,"SE|Liquids|Oil (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Freight|Liquids|Oil (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
-                   output[r,,"FE|Transport|Freight (EJ/yr)"] 
+                   output[r,,"FE|Transport|Freight|Liquids (EJ/yr)"]
                  * output[r,,"SE|Liquids|Biomass (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Freight|Liquids|Biomass (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
-                   output[r,,"FE|Transport|Freight (EJ/yr)"] 
+                   output[r,,"FE|Transport|Freight|Liquids (EJ/yr)"]
                  * output[r,,"SE|Liquids|Coal (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Freight|Liquids|Coal (EJ/yr)"))
+  tmp <- mbind(tmp,setNames(
+                   output[r,,"FE|Transport|Freight|Liquids (EJ/yr)"]
+                 * output[r,,"SE|Liquids|Hydrogen (EJ/yr)"]
+                 / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Freight|Liquids|Hydrogen (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
                    output[r,,"FE|Transport|Liquids (EJ/yr)"] 
                  * output[r,,"SE|Liquids|Biomass (EJ/yr)"]
@@ -125,17 +129,28 @@ reportCrossVariables <- function(gdx,output=NULL,regionSubsetList=NULL){
                  * output[r,,"SE|Liquids|Oil (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Liquids|Oil (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
-                 ( output[r,,"FE|Transport|Pass (EJ/yr)"] - output[r,,"FE|Transport|Electricity (EJ/yr)"] )
+                   output[r,,"FE|Transport|Liquids (EJ/yr)"]
+                 * output[r,,"SE|Liquids|Hydrogen (EJ/yr)"]
+                 / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Liquids|Hydrogen (EJ/yr)"))
+
+  tmp <- mbind(tmp,setNames(
+                 output[r,,"FE|Transport|Pass|Liquids (EJ/yr)"]
                  * output[r,,"SE|Liquids|Oil (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Pass|Liquids|Oil (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
-                 ( output[r,,"FE|Transport|Pass (EJ/yr)"] - output[r,,"FE|Transport|Electricity (EJ/yr)"] )
+                 output[r,,"FE|Transport|Pass|Liquids (EJ/yr)"]
                  * output[r,,"SE|Liquids|Biomass (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Pass|Liquids|Biomass (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
-                 ( output[r,,"FE|Transport|Pass (EJ/yr)"] - output[r,,"FE|Transport|Electricity (EJ/yr)"] )
+                 output[r,,"FE|Transport|Pass|Liquids (EJ/yr)"]
                  * output[r,,"SE|Liquids|Coal (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Pass|Liquids|Coal (EJ/yr)"))
+
+  tmp <- mbind(tmp,setNames(
+                     output[r,,"FE|Transport|Pass|Liquids (EJ/yr)"]
+                     * output[r,,"SE|Liquids|Hydrogen (EJ/yr)"]
+                     / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Pass|Liquids|Hydrogen (EJ/yr)"))
+
 
   if(tran_mod == "complex"){
       tmp <- mbind(tmp,setNames(

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -463,6 +463,7 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
   }
     
   if (tran_mod == "complex"){
+
     ## load conversion parameters
     p35_passLDV_ES_efficiency <- readGDX(gdx,"p35_passLDV_ES_efficiency", restore_zeros = FALSE)
     p35_pass_FE_share_transp <- readGDX(gdx,"p35_pass_FE_share_transp", restore_zeros = FALSE)
@@ -489,6 +490,10 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
     demFE <- demFE[fe2ue]
 
     tmp1 <- mbind(tmp1,
+                  setNames(dimSums(demFE[,, "fepet"],dim=3),             "FE|Transport|Pass|Liquids (EJ/yr)" ),
+                  setNames(dimSums(demFE[,, "fedie"],dim=3) - vm_otherFEdemand[,,'fedie'],             "FE|Transport|Freight|Liquids (EJ/yr)" ),
+                  setNames(dimSums(demFE[,, "feh2t"],dim=3),             "FE|Transport|Pass|Hydrogen (EJ/yr)" ),
+                  setNames(dimSums(demFE[,, "feelt"],dim=3),             "FE|Transport|Pass|Electricity (EJ/yr)" ),
                   setNames(dimSums(demFE[setTrainEl],dim=3),             "FE|Transport|Pass|Train|Electricity (EJ/yr)" ),
                   setNames(dimSums(demFE[,,LDV35],dim=3),                "FE|Transport|Pass|Road|LDV (EJ/yr)"),
                   setNames(dimSums(demFE[,,"apCarH2T"],dim=3),           "FE|Transport|Pass|Road|LDV|Hydrogen (EJ/yr)"),
@@ -511,9 +516,8 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
     tmp1 <- mbind(tmp1,
                   setNames(dimSums(vm_demFeForEs_trnsp[,,"eselt_frgt_",pmatch=TRUE],dim=3),"FE|Transport|Freight|Electricity (EJ/yr)"),
                   setNames(dimSums(vm_demFeForEs_trnsp[,,"eselt_pass_",pmatch=TRUE],dim=3),"FE|Transport|Pass|Electricity (EJ/yr)"),
-                  setNames(dimSums(vm_demFeForEs_trnsp[,,"esdie_frgt_",pmatch=TRUE],dim=3),"FE|Transport|Freight|Diesel (EJ/yr)"),
-                  setNames(dimSums(vm_demFeForEs_trnsp[,,"esdie_pass_",pmatch=TRUE],dim=3),"FE|Transport|Pass|Diesel (EJ/yr)"),
-                  setNames(dimSums(vm_demFeForEs_trnsp[,,"espet_pass_",pmatch=TRUE],dim=3),"FE|Transport|Pass|Petrol (EJ/yr)"),
+                  setNames(dimSums(vm_demFeForEs_trnsp[,,"esdie_frgt_",pmatch=TRUE],dim=3),"FE|Transport|Freight|Liquids (EJ/yr)"),
+                  setNames(dimSums(vm_demFeForEs_trnsp[,,c("esdie_pass_", "espet_pass_"),pmatch=TRUE],dim=3),"FE|Transport|Pass|Liquids (EJ/yr)"),
                   setNames(dimSums(vm_demFeForEs_trnsp[,,"esgat_frgt_",pmatch=TRUE],dim=3),"FE|Transport|Freight|Gases (EJ/yr)"),
                   setNames(dimSums(vm_demFeForEs_trnsp[,,"esgat_pass_",pmatch=TRUE],dim=3),"FE|Transport|Pass|Gases (EJ/yr)"),
                   setNames(dimSums(vm_demFeForEs_trnsp[,,"esh2t_pass_",pmatch=TRUE],dim=3),"FE|Transport|Pass|Hydrogen (EJ/yr)"),

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -491,7 +491,7 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
 
     tmp1 <- mbind(tmp1,
                   setNames(dimSums(demFE[,, "fepet"],dim=3),             "FE|Transport|Pass|Liquids (EJ/yr)" ),
-                  setNames(dimSums(demFE[,, "fedie"],dim=3) - vm_otherFEdemand[,,'fedie'],             "FE|Transport|Freight|Liquids (EJ/yr)" ),
+                  setNames(dimSums(demFE[,, "fedie"] - vm_otherFEdemand[,,'fedie'],dim=3),             "FE|Transport|Freight|Liquids (EJ/yr)" ),
                   setNames(dimSums(demFE[,, "feh2t"],dim=3),             "FE|Transport|Pass|Hydrogen (EJ/yr)" ),
                   setNames(dimSums(demFE[,, "feelt"],dim=3),             "FE|Transport|Pass|Electricity (EJ/yr)" ),
                   setNames(dimSums(demFE[setTrainEl],dim=3),             "FE|Transport|Pass|Train|Electricity (EJ/yr)" ),
@@ -624,11 +624,6 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
 
   if (tran_mod == "complex") {  
     tmp2 <- mbind(tmp2a,
-                  setNames(
-                    tmp1[,,"FE|Transport|Pass|Train|Electricity (EJ/yr)"] 
-                    + tmp1[,,"FE|Transport|Pass|Road|LDV|Electricity (EJ/yr)"], 
-                    "FE|Transport|Pass|Electricity (EJ/yr)"),
-                  setNames(tmp1[,,"FE|Transport|Pass|Road|LDV|Hydrogen (EJ/yr)"], "FE|Transport|Pass|Hydrogen (EJ/yr)"),
                   setNames(p35_pass_FE_share_transp * tmp1[,, "FE|Transport|non-LDV (EJ/yr)"], "FE|Transport|Pass|non-LDV (EJ/yr)"),
                   setNames((1- p35_pass_FE_share_transp) * tmp1[,, "FE|Transport|non-LDV (EJ/yr)"], "FE|Transport|Freight (EJ/yr)"),
                   setNames(p35_pass_FE_share_transp * tmp1[,, "UE|Transport|HDV (EJ/yr)"], "UE|Transport|Pass|non-LDV (EJ/yr)"),


### PR DESCRIPTION
- Aggregate transport fuel variables, `FE|Transport|<fueltype>` and `FE|Transport|{Pass|Freight}|<fueltype>` are now reported based on FE variables in `complex`.
- Derived variables in `crossVariables.R` are now reported consistently accross transport realizations, based on the aforementioned aggregates.