### PR TITLE
Reporting EDGE-T Energy Services by Drivetrain

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.155.0
+Version: 36.155.1
 Date: 2020-03-04
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
@@ -43,5 +43,5 @@ RoxygenNote: 7.0.2
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6625403750
+ValidationKey: 6625422075
 VignetteBuilder: knitr

--- a/R/reportEDGETransport.R
+++ b/R/reportEDGETransport.R
@@ -32,7 +32,7 @@ reportEDGETransport <- function(output_folder=".",
   ## NULL Definitons for codeCheck compliance
   RegionCode <- CountryCode <- cfg <- `.` <- sector <- subsector_L3 <- region <- year <- NULL
   subsector_L2 <- subsector_L1 <- aggr_mode <- vehicle_type <- det_veh <- aggr_nonmot <- NULL
-  demand_F <- demand_EJ <- remind_rep <- V25 <- aggr_veh <- NULL
+  demand_F <- demand_EJ <- remind_rep <- V25 <- aggr_veh <- technology <- NULL
 
   load(file.path(output_folder, "config.Rdata"))
 


### PR DESCRIPTION
Previously EDGE-T reporting aggregated ES demand in terms of fuel types.
For the LCA coupling, this does not make much sense, so reporting is aggregated in terms of drivetrain technology (basically the categories are given by EDGE-T).