### PR TITLE
GDP Linegraph Bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.155.1
+Version: 36.155.2
 Date: 2020-03-04
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
@@ -43,5 +43,5 @@ RoxygenNote: 7.0.2
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6625422075
+ValidationKey: 6625440400
 VignetteBuilder: knitr

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -45,7 +45,7 @@ compareScenarios <- function(mif, hist,
     if(!is.null(histdata)){
       if(all(items %in% getNames(histdata, dim=3))){
         hist_dt <- as.data.table(as.quitte(histdata[,, items]))
-        varhist <- hist_dt[model != "EDGE_SSP1"][, c("unit", "model") := list(NULL, "REMIND")]
+        varhist <- hist_dt[model == "James_IMF"][, c("unit", "model") := list(NULL, "REMIND")]
         var <- rbind(var, varhist)
       }else{
         print(sprintf("Items %s not found in historical data.", items))


### PR DESCRIPTION
- Issue was caused by additional `GDP|PPP` variables in `historical.mif` (maybe some recent update @LaviniaBaumstark) or a change in how this is handled by `data.table::dcast`.
- We use IMF data for `GDP|PPP` historical plots in linegraphs in `compareScenarios.R`.

