### PR TITLE
CompareScenarios: Restore plots of historical data in linegraphs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.157.1
-Date: 2020-03-13
+Version: 36.157.2
+Date: 2020-03-17
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -43,5 +43,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6629042714
+ValidationKey: 6630507336
 VignetteBuilder: knitr


### PR DESCRIPTION
- the model for population data was not included in the dataset filter, see #27.
- add a list with models for data in the historical dataset, `histmap`. If data
from the historical dataset is to be plotted via `lineplots_perCap`, the
variable and the model should be added to `histmap`.
