### PR TITLE
fixed reporting variable "Taxes|GHG emissions|GAMS calculated" 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.157.2
-Date: 2020-03-17
+Version: 36.157.3
+Date: 2020-03-19
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -43,5 +43,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6630507336
+ValidationKey: 6631248820
 VignetteBuilder: knitr

--- a/R/reportTax.R
+++ b/R/reportTax.R
@@ -78,6 +78,7 @@ reportTax <- function(gdx,regionSubsetList=NULL){
   fe_tax  <- readGDX(gdx, name=c('p21_tau_fe_tax','pm_tau_fe_tax'), format="first_found", react = "silent")
   fe_sub  <- readGDX(gdx, name=c('p21_tau_fe_sub','pm_tau_fe_sub'), format="first_found", react = "silent")
   p21_taxrevGHG0 <- readGDX(gdx, name=c("p21_taxrevGHG0"), format= "first_found")
+  p21_taxrevCO2luc0 <- readGDX(gdx, name=c("p21_taxrevCO2luc0"), format= "first_found")
   p21_taxrevCCS0 <- readGDX(gdx, name=c("p21_taxrevCCS0"), format= "first_found")
   p21_taxrevNetNegEmi0 <- readGDX(gdx, name=c("p21_taxrevNetNegEmi0"), format= "first_found")
   p21_taxrevFEtrans0 <- readGDX(gdx, name=c("p21_taxrevFEtrans0"), format= "first_found")
@@ -129,6 +130,7 @@ reportTax <- function(gdx,regionSubsetList=NULL){
       vm_demFeForEs  <- vm_demFeForEs[,y,][fe2es]*TWa_2_EJ  
     }} 
   p21_taxrevGHG0 <- p21_taxrevGHG0[,y,]
+  p21_taxrevCO2luc0 <- p21_taxrevCO2luc0[,y,]
   p21_taxrevCCS0 <- p21_taxrevCCS0[,y,]
   p21_taxrevNetNegEmi0 <- p21_taxrevNetNegEmi0[,y,]
   p21_taxrevFEtrans0 <- p21_taxrevFEtrans0[,y,]
@@ -536,10 +538,13 @@ reportTax <- function(gdx,regionSubsetList=NULL){
   }
   
   #tax levels of all taxes in equation q21_taxrev
-  
+  #note: CO2 from LUC is now treated separately in tax revenue recycling
+  #total GHG tax revenue = taxrevGHG0 + taxrevCO2luc0
   if (!is.null(p21_taxrevGHG0)){
     out <- mbind(out,
-                 setNames(p21_taxrevGHG0*1000,"Taxes|GHG emissions|GAMS calculated (billion US$2005/yr)"),
+                 setNames(p21_taxrevGHG0*1000,"Taxes|GHG emissions w/o CO2 LUC|GAMS calculated (billion US$2005/yr)"),
+                 setNames(p21_taxrevCO2luc0*1000,"Taxes|CO2 LUC|GAMS calculated (billion US$2005/yr)"),
+                 setNames((p21_taxrevGHG0+p21_taxrevCO2luc0)*1000,"Taxes|GHG emissions|GAMS calculated (billion US$2005/yr)"),
                  setNames(p21_taxrevCCS0*1000,"Taxes|CCS|GAMS calculated (billion US$2005/yr)"),
                  setNames(p21_taxrevNetNegEmi0*1000,"Taxes|Net-negative emissions|GAMS calculated (billion US$2005/yr)"),
                  setNames(p21_taxrevFEtrans0*1000,"Taxes|Final Energy|Transportation II|GAMS calculated (billion US$2005/yr)"),


### PR DESCRIPTION
This reflects an earlier change in REMIND tax recycling. Here the tax revenue from CO2 LUC is handled separately. "Taxes|GHG emissions|GAMS calculated" now contains the full revenue again, and there are two new reporting variables for the tax revenue w/o CO2 LUC and tax revenue from CO2 LUC