### PR TITLE
Correctly report SE|Gases contribution from Landfills

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.159.0
-Date: 2020-03-24
+Version: 36.159.1
+Date: 2020-03-25
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -43,5 +43,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6633368550
+ValidationKey: 6633748486
 VignetteBuilder: knitr

--- a/R/reportSE.R
+++ b/R/reportSE.R
@@ -280,9 +280,13 @@ reportSE <- function(gdx,regionSubsetList=NULL){
 #                                 - tmp1[,,"SE|Solids|Traditional Biomass (EJ/yr)"],"SE|Solids|Biomass (EJ/yr)"))
 
   if (!(is.null(vm_macBase) & is.null(vm_emiMacSector))){
-    #correction for the reused gas from waste landfills
+    ## correction for the reused gas from waste landfills
+    MtCH4_2_TWa <- readGDX(gdx, "sm_MtCH4_2_TWa")
+    if(is.null(MtCH4_2_TWa)){
+      MtCH4_2_TWa <- 0.001638
+    }
     tmp1 <- mbind(tmp1, setNames(
-                          0.001638 * (vm_macBase[,,"ch4wstl"] - vm_emiMacSector[,,"ch4wstl"]),
+                          MtCH4_2_TWa * (vm_macBase[,,"ch4wstl"] - vm_emiMacSector[,,"ch4wstl"]),
                           "SE|Gases|Waste (EJ/yr)"))
     tmp1[,,"SE|Gases (EJ/yr)"] <- tmp1[,,"SE|Gases (EJ/yr)"] + tmp1[,,"SE|Gases|Waste (EJ/yr)"] 
   }

--- a/R/reportSE.R
+++ b/R/reportSE.R
@@ -281,9 +281,10 @@ reportSE <- function(gdx,regionSubsetList=NULL){
 
   if (!(is.null(vm_macBase) & is.null(vm_emiMacSector))){
     #correction for the reused gas from waste landfills
-  tmp1[,,"SE|Gases (EJ/yr)"] <- tmp1[,,"SE|Gases (EJ/yr)"] +
-                                0.001638 * (vm_macBase[,,"ch4wstl"] 
-                                            -vm_emiMacSector[,,"ch4wstl"]) 
+    tmp1 <- mbind(tmp1, setNames(
+                          0.001638 * (vm_macBase[,,"ch4wstl"] - vm_emiMacSector[,,"ch4wstl"]),
+                          "SE|Gases|Waste (EJ/yr)"))
+    tmp1[,,"SE|Gases (EJ/yr)"] <- tmp1[,,"SE|Gases (EJ/yr)"] + tmp1[,,"SE|Gases|Waste (EJ/yr)"] 
   }
   # add global values
   out <- mbind(tmp1,dimSums(tmp1,dim=1))


### PR DESCRIPTION
Now there is a variable `SE|Gases|Waste`, so that the sum of subcategories for `SE|Gases` adds up.
This PR is related (but not strictly depending on) https://github.com/remindmodel/remind/pull/116