### PR TITLE
Add old GDP file for testing backward compatibility.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.git$
+^inst/extdata/old\.gdx$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.159.2
-Date: 2020-03-31
+Version: 36.160.0
+Date: 2020-04-15
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -43,5 +43,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6635936384
+ValidationKey: 6641507200
 VignetteBuilder: knitr

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Simply run the following command twice with the location of each GDX as argument
 
 ```{r}
 a <- convGDX2mif("/where/the/first/GDX/is/fulldata.gdx")
+a <- convGDX2mif("/<repository>/inst/extdata/old.gdx")
+## this might also work if the working directory is the repository main folder
 a <- convGDX2mif(system.file("extdata", "old.gdx", package = "remind"))
 ```
 
@@ -32,7 +34,7 @@ in R follow these steps:
 
 - In `tests/testthat/test-convGDX2mif.R` add the location of the two GDX's. Example:
 ```{r}
-my_gdxs <- c("/path/to/fulldata.gdx", system.file("extdata", "old.gdx", package = "remind"))
+my_gdxs <- c("/path/to/fulldata.gdx", "../../inst/extdata/old.gdx")
 
 ```
 - In RStudio hit Ctr+Shift+T or run `devtools::test()` in the command

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# remind
+Contains the REMIND-specific routines for data and model output manipulation.
+
+## Testing
+
+Due to software limitations on the cluster, our R packages --- which
+include the package "remind" that post-processes our REMIND results
+--- are currently not being installed under the condition of
+successful testing each time a new commit happens (packages are being
+tested but the installation happens regardless of the result).  This
+means that if a user commits a version of **REMIND** that does not
+work then all REMIND runs happening at the moment (and until the next
+working version is installed) will fail to report results.  To avoid
+this situation, until further notice, you are advised to run the tests
+manually before committing a new version of the R package.  To do so,
+use the `fulldata.gdx` from your most recent REMIND run (if you don't
+have a very recent one simply start one -- it's always good to keep up
+with using the model) and the `old.gdx` distributed with this package.
+
+Simply run the following command twice with the location of each GDX as argument:
+
+```{r}
+a <- convGDX2mif("/where/the/first/GDX/is/fulldata.gdx")
+a <- convGDX2mif(system.file("extdata", "old.gdx", package = "remind"))
+```
+
+and proceed with `lucode::buildlibrary()` as usual.
+
+
+As an alternative, if you want to get familiar with how testing works
+in R follow these steps:
+
+- In `tests/testthat/test-convGDX2mif.R` add the location of the two GDX's. Example:
+```{r}
+my_gdxs <- c("/path/to/fulldata.gdx", system.file("extdata", "old.gdx", package = "remind"))
+
+```
+- In RStudio hit Ctr+Shift+T or run `devtools::test()` in the command
+  line
+
+If testing was successful proceed with `lucode::buildlibrary()` as
+usual.

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -1,11 +1,14 @@
 context("REMIND reporting")
 
 test_that("Test if REMIND reporting is produced as it should", {
-  
+
   library(gdx)
 
+  ## add GDXs for comparison here:
+  my_gdxs <- NULL
+
   runParallelTests <- function(gdxs=NULL,cores=0,par=FALSE){
-    
+
     new_gdxs <- NULL
     if (is.null(gdxs) & file.exists("/p/projects/")) {
       gdxs <- system2("find","/p/projects/remind/runs/r* -name fulldata.gdx",stdout=T,stderr = FALSE)
@@ -40,6 +43,6 @@ test_that("Test if REMIND reporting is produced as it should", {
     unlink(new_gdxs)
   }
 
-  expect_error(runParallelTests(),regexp = NA)
+  expect_error(runParallelTests(my_gdxs),regexp = NA)
 
 })


### PR DESCRIPTION
- Add README.
- Add Anastasis recipe for testing backward compatibility to README.
- Add `old.gdx` to `inst/extdata`. Add the file to buildignore, so that it is not inflating the size of the installed package.
- Slightly modify the test script to have a more convenient interface.