### PR TITLE
Fix warnings from comparison scalar vs vector in reportTechnology

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.160.0
+Version: 36.160.1
 Date: 2020-04-15
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
@@ -43,5 +43,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6641507200
+ValidationKey: 6641525567
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.159.2
-Date: 2020-03-31
+Version: 36.159.3
+Date: 2020-04-15
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -43,5 +43,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6635936384
+ValidationKey: 6641378631
 VignetteBuilder: knitr

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -48,13 +48,8 @@ reportTechnology <- function(gdx,output=NULL,regionSubsetList=NULL) {
       inco0[,i,] <- pm_data
   }
   # use pm_inco0_t for v_investcost for REMIND 1.6 where it was 0 for all non-learning technologies
-  for (te in getNames(v_investcost)) {
-    for (t in getYears(v_investcost)) {
-       if(v_investcost[,t,te] == 0) {
-       v_investcost[,t,te] <- pm_inco0_t[,t,te]
-    }
-    }
-  }
+  v_investcost[v_investcost == 0] <- pm_inco0_t[v_investcost == 0]
+
   pm_data      <- collapseNames(readGDX(gdx,name=c("pm_data"),format = "first_found")[,,"omf"])
   omf <- new.magpie(getRegions(pm_data),y,magclass::getNames(pm_data))
   for(i in y){

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -174,7 +174,7 @@ reportTechnology <- function(gdx,output=NULL,regionSubsetList=NULL) {
           int2ext[[report_str("Electricity|Storage|Battery|For CSP", category, unit)]] <- report_str("Electricity|Solar|CSP", unit="EJ/yr", predicate="SE")
           int2ext[[report_str("Electricity|Storage|Battery|For Wind", category, unit)]] <- report_str("Electricity|Wind", unit="EJ/yr", predicate="SE")
 
-      }else if(map == carmap){
+      }else if(all(map == carmap)){
           ## cars need a special mapping, too
           ## for global avgs we use FEs as weights
           int2ext[[report_str("Transport|Pass|Road|LDV|ICE", category, unit)]] <- report_str("Transport|Pass|Road|LDV|Liquids", unit="EJ/yr", predicate="FE")

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ with using the model) and the `old.gdx` distributed with this package.
 Simply run the following command twice with the location of each GDX as argument:
 
 ```{r}
-a <- convGDX2mif("/where/the/first/GDX/is/fulldata.gdx")
-a <- convGDX2mif("/<repository>/inst/extdata/old.gdx")
+a <- convGDX2MIF("/where/the/first/GDX/is/fulldata.gdx")
+a <- convGDX2MIF("/<repository>/inst/extdata/old.gdx")
 ## this might also work if the working directory is the repository main folder
-a <- convGDX2mif(system.file("extdata", "old.gdx", package = "remind"))
+a <- convGDX2MIF(system.file("extdata", "old.gdx", package = "remind"))
 ```
 
 and proceed with `lucode::buildlibrary()` as usual.


### PR DESCRIPTION
See issue #32 

Tested against recent `fulldata.gdx` and `old.gdx`.