### PR TITLE
Bugfix: NAs in secondary energy demand substituted with 0 if synfuels…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.161.0
+Version: 36.161.1
 Date: 2020-05-04
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
@@ -43,5 +43,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6648561460
+ValidationKey: 6648579846
 VignetteBuilder: knitr

--- a/R/reportSE.R
+++ b/R/reportSE.R
@@ -61,6 +61,14 @@ reportSE <- function(gdx,regionSubsetList=NULL){
   ## variables
   prodSe <- readGDX(gdx,name=c("vm_prodSe","v_seprod"),field="l",restore_zeros=FALSE,format="first_found")*pm_conv_TWa_EJ
   prodSe <- mselect(prodSe,all_enty1=sety)
+
+  if (any(getNames(prodSe) %in% c("seh2.seliqfos.MeOH", "seh2.segafos.h22ch4") == TRUE)) {
+    ## if synfuels are activated, there might be no demand until 2020. This can lead to NAs that need to be substituted with 0
+    tmp_syn <- prodSe[, c("y2005", "y2010", "y2015", "y2020"), c("seh2.seliqfos.MeOH", "seh2.segafos.h22ch4")]
+    tmp_syn[is.na(tmp_syn)] <- 0
+    prodSe[, c("y2005", "y2010", "y2015", "y2020"), c("seh2.seliqfos.MeOH", "seh2.segafos.h22ch4")] <- tmp_syn
+  }
+
   #  storloss only exist for versions previous to the power module creation and for the IntC power module realisation
   if ((is.null(power_realisation)) || (power_realisation == "IntC")) {
     storLoss <- readGDX(gdx,name=c("v32_storloss","v_storloss"), field = "l", restore_zeros=TRUE, format ="first_found")*pm_conv_TWa_EJ


### PR DESCRIPTION
… are activated.
This commit should avoid NAs appearing before demand for synfuels is higher than 0. It should leave unaffected any other NA appearing, therefore avoiding to hide errors.