### PR TITLE
Emi ccu reporting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.161.1
-Date: 2020-05-04
+Version: 36.162.0
+Date: 2020-05-05
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -43,5 +43,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6648579846
+ValidationKey: 6649106940
 VignetteBuilder: knitr

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -343,6 +343,18 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
   )
   p_share_carbonCapture_stor[is.na(p_share_carbonCapture_stor)] <- 1
   
+  # share of captured carbon that is biogenic
+  p_share_cco2_bio <- (
+    dimSums(v_emi[,,pebio][,,"cco2"], dim=3) /
+      vm_co2capture)
+  
+  # share of captured carbon from DAC
+  p_share_cco2_DAC <- (
+    v33_emiDAC /
+      vm_co2capture)
+    
+
+  
   ####### internal function for cumulated values ############
   cumulatedValue <- function(var,i_pm_ts=pm_ts){
     ts <- i_pm_ts[,getYears(var),]
@@ -540,7 +552,21 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
     
     setNames(
       dimSums(vm_co2CCUshort,dim=3) * GtC_2_MtCO2,
-      "Carbon Sequestration|CCU (Mt CO2/yr)")
+      "Carbon Sequestration|CCU (Mt CO2/yr)"),
+    
+    setNames(
+      dimSums(vm_co2CCUshort,dim=3) * p_share_cco2_bio * GtC_2_MtCO2,
+      "Carbon Sequestration|CCU|Biomass (Mt CO2/yr)"),
+    
+    setNames(
+      dimSums(vm_co2CCUshort,dim=3) * p_share_cco2_DAC * GtC_2_MtCO2,
+      "Carbon Sequestration|CCU|DAC (Mt CO2/yr)"),
+    
+    setNames(
+      dimSums(vm_co2CCUshort,dim=3) * (1-p_share_cco2_DAC-p_share_cco2_bio) *
+        GtC_2_MtCO2,
+      "Carbon Sequestration|CCU|Fossil (Mt CO2/yr)")
+    
   )
   # cumulative CDR emissions
   tmp <- mbind(tmp, 

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -334,26 +334,17 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
                                           output[,y,"FE|+|Gases (EJ/yr)"])
   }
   
+  
+  
   # Share of captured carbon, that is actually sequestered.  The introduction 
   # of CCU made it necessary to add the "slack" variable v_co2capturevalve, 
   # that allows for immediate releasing
   p_share_carbonCapture_stor <- (
-      vm_co2CCS[,,"cco2.ico2.ccsinje.1"]
+    vm_co2CCS[,,"cco2.ico2.ccsinje.1"]
     / dimSums(mselect(vm_co2capture, all_enty = "cco2"), dim = 3)
   )
   p_share_carbonCapture_stor[is.na(p_share_carbonCapture_stor)] <- 1
   
-  # share of captured carbon that is biogenic
-  p_share_cco2_bio <- (
-    dimSums(v_emi[,,pebio][,,"cco2"], dim=3) /
-      vm_co2capture)
-  
-  # share of captured carbon from DAC
-  p_share_cco2_DAC <- (
-    v33_emiDAC /
-      vm_co2capture)
-    
-
   
   ####### internal function for cumulated values ############
   cumulatedValue <- function(var,i_pm_ts=pm_ts){
@@ -484,101 +475,7 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
     setNames((vm_eminegregi[,,"co2luc"] ) * GtC_2_MtCO2,                                         "Emi|CO2|Land-Use Change (Mt CO2/yr)")
   )
   
-  ### CDR/CCU emissions ##########################################################################################  
-  ### report only negative values of CO2 LUC as CDR
-  CDRco2luc <- new.magpie(getRegions(vm_eminegregi),getYears(vm_eminegregi),magclass::getNames(vm_eminegregi),fill=0)
-  CDRco2luc <- vm_eminegregi
-  CDRco2luc[CDRco2luc>0] <- 0
-  tmp <- mbind(
-    tmp,
-    
-    setNames(
-      CDRco2luc[,,"co2luc"] * GtC_2_MtCO2,
-      "Emi|CO2|CDR|Land-Use Change (Mt CO2/yr)"),
-    
-    # does not contain the IndustryCCS applied to Biogas, Biosolids, Bioliquids ...
-    setNames(
-        dimSums(mselect(v_emi, all_enty = pebio, all_enty2 = "cco2"), dim = 3)
-      * GtC_2_MtCO2 
-      * (-1), 
-      "Emi|CO2|BECC (Mt CO2/yr)"),
-    
-    # does not contain the IndustryCCS applied to Biogas, Biosolids, Bioliquids ...
-    setNames(
-        dimSums(mselect(v_emi, all_enty = pebio, all_enty2 = "cco2"), dim = 3)
-      * p_share_carbonCapture_stor 
-      * GtC_2_MtCO2 
-      * (-1),
-      "Emi|CO2|CDR|BECCS (Mt CO2/yr)"),
-    
-    setNames(v33_emiEW[,,"emiEW"] * GtC_2_MtCO2, "Emi|CO2|CDR|EW (Mt CO2/yr)"),
-    setNames(v33_emiDAC[,,"emiDAC"] * GtC_2_MtCO2, "Emi|CO2|DAC (Mt CO2/yr)"),
-    setNames(
-        v33_emiDAC[,,"emiDAC"] 
-      * p_share_carbonCapture_stor
-      * GtC_2_MtCO2,
-      "Emi|CO2|CDR|DACCS (Mt CO2/yr)"),
-    
-    setNames(
-      v33_emiDAC[,,"emiDAC"] * GtC_2_MtCO2 * (-1),
-      "Carbon Sequestration|Direct Air Capture (Mt CO2/yr)")
-  )
-  
-  tmp <- mbind(
-    tmp, 
-    
-    setNames(
-        ( v33_emiEW[,,"emiEW"]
-        + ( ( v33_emiDAC[,,"emiDAC"]
-            - dimSums(
-                mselect(v_emi, all_enty = pebio, all_enty2 = "cco2"), 
-                dim = 3)
-            )
-          * p_share_carbonCapture_stor
-          )
-        + CDRco2luc[,,"co2luc"]
-        ) 
-      * GtC_2_MtCO2,
-      "Emi|CO2|CDR (Mt CO2/yr)"),
-    
-    setNames(
-        dimSums(mselect(vm_co2capture, all_enty = "cco2"), dim = 3) 
-      * GtC_2_MtCO2,
-      "Carbon Sequestration|CC (Mt CO2/yr)"),
-    
-    setNames(
-      vm_co2CCS[,,"cco2.ico2.ccsinje.1"] * GtC_2_MtCO2,
-      "Carbon Sequestration|CCS (Mt CO2/yr)"),
-    
-    setNames(
-      dimSums(vm_co2CCUshort,dim=3) * GtC_2_MtCO2,
-      "Carbon Sequestration|CCU (Mt CO2/yr)"),
-    
-    setNames(
-      dimSums(vm_co2CCUshort,dim=3) * p_share_cco2_bio * GtC_2_MtCO2,
-      "Carbon Sequestration|CCU|Biomass (Mt CO2/yr)"),
-    
-    setNames(
-      dimSums(vm_co2CCUshort,dim=3) * p_share_cco2_DAC * GtC_2_MtCO2,
-      "Carbon Sequestration|CCU|DAC (Mt CO2/yr)"),
-    
-    setNames(
-      dimSums(vm_co2CCUshort,dim=3) * (1-p_share_cco2_DAC-p_share_cco2_bio) *
-        GtC_2_MtCO2,
-      "Carbon Sequestration|CCU|Fossil (Mt CO2/yr)")
-    
-  )
-  # cumulative CDR emissions
-  tmp <- mbind(tmp, 
-               setNames(cumulatedValue(tmp[,,"Emi|CO2|CDR|Land-Use Change (Mt CO2/yr)"]), "Emi|CO2|CDR|Land-Use Change|Cumulated (Mt CO2/yr)"),
-               setNames(cumulatedValue(tmp[,,"Emi|CO2|CDR|BECCS (Mt CO2/yr)"]),           "Emi|CO2|CDR|BECCS|Cumulated (Mt CO2/yr)"),
-               setNames(cumulatedValue(tmp[,,"Emi|CO2|CDR|EW (Mt CO2/yr)"]),              "Emi|CO2|CDR|EW|Cumulated (Mt CO2/yr)"),
-               setNames(cumulatedValue(tmp[,,"Emi|CO2|CDR|DACCS (Mt CO2/yr)"]),           "Emi|CO2|CDR|DACCS|Cumulated (Mt CO2/yr)"),
-               setNames(cumulatedValue(tmp[,,"Carbon Sequestration|CCS (Mt CO2/yr)"]),    "Carbon Sequestration|CCS|Cumulated (Mt CO2/yr)"),
-               setNames(cumulatedValue(tmp[,,"Emi|CO2|CDR (Mt CO2/yr)"]),                 "Emi|CO2|CDR|Cumulated (Mt CO2/yr)")
-  )
-               
-  
+ 
   # Emissions by PE and carrier, use function "emi_carrier" declared above ############################################################################
   tmp <- mbind(tmp,
     emi_carrier(v_emi,dataoc,oc2te,sety,pebio,"seel","cco2",GtC_2_MtCO2,pe2se$all_te,      name="Emi|CO2|Carbon Capture|Biomass|Supply|Electricity|w/ couple prod (Mt CO2/yr)"),
@@ -930,6 +827,8 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
   )
 
   ## Add some LDV specific emission reporting (complex module only)
+  
+
   if(tran_mod == "complex"){
     LDV35      <- readGDX(gdx,"LDV35")
 
@@ -973,6 +872,125 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
       setNames( dimSums(p_ef_dem[,,c("fedie", "feelt", "fegat")] * dimSums(vm_demFeForEs_trnsp[,, "frgt_sm", pmatch=T], dim=c(3.2, 3.3))[,,c("fedie", "feelt", "fegat")], dim=3), "Emi|CO2|Transport|Freight|Short-Medium Distance|Demand (Mt CO2/yr)"))    
     
   }
+  
+  
+  
+  ### CDR/CCU emissions ##########################################################################################  
+  ### moved here to include industry CCS
+
+  
+  # calculate CCU/CDR share parameters
+
+  ### share of captured carbon that is biogenic
+  # technology (pe2se technology cco2 + industry cco2 biomass)/captured co2
+  p_share_cco2_bio <- (
+    (dimSums(v_emi[,,pebio][,,"cco2"], dim=3) + 
+      collapseNames(tmp[,,"Emi|CO2|Carbon Capture and Storage|Biomass|Energy|Demand|Industry (Mt CO2/yr)"]/
+                      GtC_2_MtCO2))/
+      vm_co2capture)
+  
+  # share of captured carbon from DAC
+  p_share_cco2_DAC <- (
+    v33_emiDAC /
+      vm_co2capture)
+  
+  # LUC CDR, report only negative values of CO2 LUC as CDR
+  CDRco2luc <- new.magpie(getRegions(vm_eminegregi),getYears(vm_eminegregi),magclass::getNames(vm_eminegregi),fill=0)
+  CDRco2luc <- vm_eminegregi
+  CDRco2luc[CDRco2luc>0] <- 0
+  tmp <- mbind(
+    tmp,
+    
+    setNames(
+      CDRco2luc[,,"co2luc"] * GtC_2_MtCO2,
+      "Emi|CO2|CDR|Land-Use Change (Mt CO2/yr)"),
+    
+    # bioenergy carbon capture: pe2se technology cco2 + industry cco2 biomass
+    setNames(
+      (dimSums(mselect(v_emi, all_enty = pebio, all_enty2 = "cco2"), dim = 3)
+      * GtC_2_MtCO2 
+      + collapseNames(tmp[,,"Emi|CO2|Carbon Capture and Storage|Biomass|Energy|Demand|Industry (Mt CO2/yr)"]))*(-1), 
+      "Emi|CO2|BECC (Mt CO2/yr)"),
+    # bioenergy carbon capture: pe2se technology cco2 + industry cco2 biomass
+    setNames(
+      (dimSums(mselect(v_emi, all_enty = pebio, all_enty2 = "cco2"), dim = 3)
+       * GtC_2_MtCO2 
+       + collapseNames(tmp[,,"Emi|CO2|Carbon Capture and Storage|Biomass|Energy|Demand|Industry (Mt CO2/yr)"]))
+      * p_share_carbonCapture_stor 
+      * (-1),
+      "Emi|CO2|CDR|BECCS (Mt CO2/yr)"),
+    
+    setNames(v33_emiEW[,,"emiEW"] * GtC_2_MtCO2, "Emi|CO2|CDR|EW (Mt CO2/yr)"),
+    setNames(v33_emiDAC[,,"emiDAC"] * GtC_2_MtCO2, "Emi|CO2|DAC (Mt CO2/yr)"),
+    setNames(
+      v33_emiDAC[,,"emiDAC"] 
+      * p_share_carbonCapture_stor
+      * GtC_2_MtCO2,
+      "Emi|CO2|CDR|DACCS (Mt CO2/yr)"),
+    
+    setNames(
+      v33_emiDAC[,,"emiDAC"] * GtC_2_MtCO2 * (-1),
+      "Carbon Sequestration|Direct Air Capture (Mt CO2/yr)")
+  )
+  
+  tmp <- mbind(
+    tmp, 
+    
+    setNames(
+      ( v33_emiEW[,,"emiEW"]
+        + ( ( v33_emiDAC[,,"emiDAC"]
+              - dimSums(
+                mselect(v_emi, all_enty = pebio, all_enty2 = "cco2"), 
+                dim = 3) 
+              - collapseNames(tmp[,,"Emi|CO2|Carbon Capture and Storage|Biomass|Energy|Demand|Industry (Mt CO2/yr)"]/
+                                GtC_2_MtCO2)
+                
+        )
+        * p_share_carbonCapture_stor
+        )
+        + CDRco2luc[,,"co2luc"]
+      ) 
+      * GtC_2_MtCO2,
+      "Emi|CO2|CDR (Mt CO2/yr)"),
+    
+    setNames(
+      dimSums(mselect(vm_co2capture, all_enty = "cco2"), dim = 3) 
+      * GtC_2_MtCO2,
+      "Carbon Sequestration|CC (Mt CO2/yr)"),
+    
+    setNames(
+      vm_co2CCS[,,"cco2.ico2.ccsinje.1"] * GtC_2_MtCO2,
+      "Carbon Sequestration|CCS (Mt CO2/yr)"),
+    
+    setNames(
+      dimSums(vm_co2CCUshort,dim=3) * GtC_2_MtCO2,
+      "Carbon Sequestration|CCU (Mt CO2/yr)"),
+    
+    setNames(
+      dimSums(vm_co2CCUshort,dim=3) * p_share_cco2_bio * GtC_2_MtCO2,
+      "Carbon Sequestration|CCU|Biomass (Mt CO2/yr)"),
+    
+    setNames(
+      dimSums(vm_co2CCUshort,dim=3) * p_share_cco2_DAC * GtC_2_MtCO2,
+      "Carbon Sequestration|CCU|DAC (Mt CO2/yr)"),
+    
+    setNames(
+      dimSums(vm_co2CCUshort,dim=3) * (1-p_share_cco2_DAC-p_share_cco2_bio) *
+        GtC_2_MtCO2,
+      "Carbon Sequestration|CCU|Fossil (Mt CO2/yr)")
+    
+  )
+  # cumulative CDR emissions
+  tmp <- mbind(tmp, 
+               setNames(cumulatedValue(tmp[,,"Emi|CO2|CDR|Land-Use Change (Mt CO2/yr)"]), "Emi|CO2|CDR|Land-Use Change|Cumulated (Mt CO2/yr)"),
+               setNames(cumulatedValue(tmp[,,"Emi|CO2|CDR|BECCS (Mt CO2/yr)"]),           "Emi|CO2|CDR|BECCS|Cumulated (Mt CO2/yr)"),
+               setNames(cumulatedValue(tmp[,,"Emi|CO2|CDR|EW (Mt CO2/yr)"]),              "Emi|CO2|CDR|EW|Cumulated (Mt CO2/yr)"),
+               setNames(cumulatedValue(tmp[,,"Emi|CO2|CDR|DACCS (Mt CO2/yr)"]),           "Emi|CO2|CDR|DACCS|Cumulated (Mt CO2/yr)"),
+               setNames(cumulatedValue(tmp[,,"Carbon Sequestration|CCS (Mt CO2/yr)"]),    "Carbon Sequestration|CCS|Cumulated (Mt CO2/yr)"),
+               setNames(cumulatedValue(tmp[,,"Emi|CO2|CDR (Mt CO2/yr)"]),                 "Emi|CO2|CDR|Cumulated (Mt CO2/yr)")
+  )
+  
+  
   
   ## create the normal aliases for the more detailed names that specify that couple production is included
   tmp <- mbind(tmp,

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -992,8 +992,15 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
                setNames(tmp[,,"Emi|CO2|Fossil Fuels and Industry|Energy Supply (Mt CO2/yr)"] +
                     tmp[,,"Emi|CO2|Carbon Capture and Storage|Biomass|Supply|w/ couple prod (Mt CO2/yr)"] -
                     tmp[,,"Emi|CO2|Energy|Supply|Electricity|Gross (Mt CO2/yr)"],
-                   "Emi|CO2|Energy|Supply|Non-Elec (Mt CO2/yr)")
+                   "Emi|CO2|Energy|Supply|Non-Elec|Gross (Mt CO2/yr)")
   )
+  
+  tmp <- mbind(tmp,
+               setNames(tmp[,,"Emi|CO2|Fossil Fuels and Industry|Energy Supply (Mt CO2/yr)"] -
+                          tmp[,,"Emi|CO2|Energy|Supply|Electricity (Mt CO2/yr)"],
+                        "Emi|CO2|Energy|Supply|Non-Elec (Mt CO2/yr)")
+  )
+  
   
   tmp <- mbind(tmp,
                setNames(-1 * tmp[,,"Emi|CO2|Carbon Capture and Storage|Biomass (Mt CO2/yr)"], 


### PR DESCRIPTION
Fix reporting of non-electric energy supply emissions, Supply|Non-Elec before referred to gross emissions, now refers to net emissions and introduced Supply|Non-Elec|Gross to refer gross emissions.
Add distinction between atmospheric and fossil captured carbon for CCU. Add biogenic captured CO2 from industry CCS to CCU and CDR variables. 
