### PR TITLE
Report Gases from non-bio Origin, i.e., segafos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.162.2
-Date: 2020-05-06
+Version: 36.162.3
+Date: 2020-05-18
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -43,5 +43,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6649505336
+ValidationKey: 6653863200
 VignetteBuilder: knitr

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -651,9 +651,13 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
                  )
   } else if (stat_mod == "off"){
     tmp2 = mbind(tmp2,
-                 setNames(tmp1[,,"FE|Buildings|Solids (EJ/yr)"] + tmp1[,,"FE|Industry|Solids (EJ/yr)"] ,"FE|Other Sector|Solids (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"fesos",pmatch=TRUE],dim=3),"FE|Other Sector|Solids (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"fegas",pmatch=TRUE],dim=3),"FE|Other Sector|Gases (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"sesobio.fesos.tdbiosos"],dim=3),"FE|Other Sector|Solids|Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"sesofos.fesos.tdfossos"],dim=3),"FE|Other Sector|Solids|Fossil (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"segabio.fegas.tdbiogas"],dim=3),"FE|Other Sector|Gases|Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"segafos.fegas.tdfosgas"],dim=3),"FE|Other Sector|Gases|Fossil (EJ/yr)"),
                  setNames(tmp1[,,"FE|Buildings|Liquids (EJ/yr)"] + tmp1[,,"FE|Industry|Liquids (EJ/yr)"] + tmpCDR4[,,"FE|CDR|Liquids (EJ/yr)"],"FE|Other Sector|Liquids (EJ/yr)"),
-                 setNames(tmp1[,,"FE|Buildings|Gases (EJ/yr)"] + tmp1[,,"FE|Industry|Gases (EJ/yr)"] + tmpCDR4[,,"FE|CDR|Gases (EJ/yr)"],"FE|Other Sector|Gases (EJ/yr)"),
                  setNames(tmp1[,,"FE|Buildings|Hydrogen (EJ/yr)"] + tmp1[,,"FE|Industry|Hydrogen (EJ/yr)"]+ tmpCDR4[,,"FE|CDR|Hydrogen (EJ/yr)"],"FE|Other Sector|Hydrogen (EJ/yr)"),
                  setNames(tmp1[,,"FE|Buildings|Electricity (EJ/yr)"] + tmp1[,,"FE|Industry|Electricity (EJ/yr)"]+ tmpCDR4[,,"FE|CDR|Electricity (EJ/yr)"],"FE|Other Sector|Electricity (EJ/yr)"),
                  setNames(tmp1[,,"FE|Buildings|Heat (EJ/yr)"] + tmp1[,,"FE|Industry|Heat (EJ/yr)"],"FE|Other Sector|Heat (EJ/yr)")

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -651,17 +651,19 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
                  )
   } else if (stat_mod == "off"){
     tmp2 = mbind(tmp2,
-                 setNames(dimSums(prodFE[,,"fesos",pmatch=TRUE],dim=3),"FE|Other Sector|Solids (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"fegas",pmatch=TRUE],dim=3),"FE|Other Sector|Gases (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"sesobio.fesos.tdbiosos"],dim=3),"FE|Other Sector|Solids|Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"sesofos.fesos.tdfossos"],dim=3),"FE|Other Sector|Solids|Fossil (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"segabio.fegas.tdbiogas"],dim=3),"FE|Other Sector|Gases|Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"segafos.fegas.tdfosgas"],dim=3),"FE|Other Sector|Gases|Fossil (EJ/yr)"),
+                 setNames(tmp1[,,"FE|Buildings|Solids (EJ/yr)"] + tmp1[,,"FE|Industry|Solids (EJ/yr)"] ,"FE|Other Sector|Solids (EJ/yr)"),
                  setNames(tmp1[,,"FE|Buildings|Liquids (EJ/yr)"] + tmp1[,,"FE|Industry|Liquids (EJ/yr)"] + tmpCDR4[,,"FE|CDR|Liquids (EJ/yr)"],"FE|Other Sector|Liquids (EJ/yr)"),
+                 setNames(tmp1[,,"FE|Buildings|Gases (EJ/yr)"] + tmp1[,,"FE|Industry|Gases (EJ/yr)"] + tmpCDR4[,,"FE|CDR|Gases (EJ/yr)"],"FE|Other Sector|Gases (EJ/yr)"),
                  setNames(tmp1[,,"FE|Buildings|Hydrogen (EJ/yr)"] + tmp1[,,"FE|Industry|Hydrogen (EJ/yr)"]+ tmpCDR4[,,"FE|CDR|Hydrogen (EJ/yr)"],"FE|Other Sector|Hydrogen (EJ/yr)"),
                  setNames(tmp1[,,"FE|Buildings|Electricity (EJ/yr)"] + tmp1[,,"FE|Industry|Electricity (EJ/yr)"]+ tmpCDR4[,,"FE|CDR|Electricity (EJ/yr)"],"FE|Other Sector|Electricity (EJ/yr)"),
                  setNames(tmp1[,,"FE|Buildings|Heat (EJ/yr)"] + tmp1[,,"FE|Industry|Heat (EJ/yr)"],"FE|Other Sector|Heat (EJ/yr)")
                  )
+    if("segabio" %in% se_Gas){
+      tmp2 <- mbind(tmp2,
+                 setNames(dimSums(prodFE[,,"segabio.fegas.tdbiogas"],dim=3),"FE|Other Sector|Gases|Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"segafos.fegas.tdfosgas"],dim=3),"FE|Other Sector|Gases|Non-Biomass (EJ/yr)")
+                 )
+      }
   }
     
     tmp2 = mbind(tmp2,

--- a/R/reportSE.R
+++ b/R/reportSE.R
@@ -297,6 +297,11 @@ reportSE <- function(gdx,regionSubsetList=NULL){
         se.prod(prodSe,dataoc,oc2te,sety,pety,"sedie",                      name = "SE|Liquids|sedie (EJ/yr)")
         )
    }
+  if("segafos" %in% se_Gas){
+    tmp1 <- mbind(tmp1,
+                  se.prod(prodSe,dataoc,oc2te,sety,pety,"segafos",                     name = "SE|Gases|Non-Biomass (EJ/yr)")
+                  )
+  }
   
 #    tmp1 <- mbind(tmp1, setNames(se.prod(prodSe,dataoc,oc2te,sety,pebio ,se_Solids, name = NULL)
 #                                 - tmp1[,,"SE|Solids|Traditional Biomass (EJ/yr)"],"SE|Solids|Biomass (EJ/yr)"))


### PR DESCRIPTION
This is required to calculate PE demand shares for gases on the FE level.

Example: You want to calculate the share of gas from coal gasification for industry.
```
FE|Industry|Gases 
x FE|Buildings and Industry|Gases|Non-Biomass / FE|Buildings and Industry|Gases # this is the share of segafos.fegas.tdfosgas in fegas
x SE|Gases|Coal / SE|Gases|Non-Biomass # the share of coal in segafos
```

Note that, in order to have accurate reporting, at least one reporting variable should exist for every important variable in GAMS.