### PR TITLE
Add AR6 Variable to EDGE-T reporting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.162.3
-Date: 2020-05-18
+Version: 36.163.0
+Date: 2020-06-05
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -43,5 +43,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6653863200
+ValidationKey: 6660501340
 VignetteBuilder: knitr

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -118,10 +118,6 @@ reportCrossVariables <- function(gdx,output=NULL,regionSubsetList=NULL){
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Freight|Liquids|Hydrogen (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
                    output[r,,"FE|Transport|Liquids (EJ/yr)"] 
-                 * output[r,,"SE|Liquids|Biomass (EJ/yr)"]
-                 / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Liquids|Biomass (EJ/yr)"))
-  tmp <- mbind(tmp,setNames(
-                   output[r,,"FE|Transport|Liquids (EJ/yr)"] 
                  * output[r,,"SE|Liquids|Coal (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Liquids|Coal (EJ/yr)"))
   tmp <- mbind(tmp,setNames(

--- a/R/reportEDGETransport.R
+++ b/R/reportEDGETransport.R
@@ -257,6 +257,18 @@ reportEDGETransport <- function(output_folder=".",
             unit="EJ/yr", value=sum(value)),
           by=c("model", "scenario", "region", "period")]), use.names = TRUE)
 
+  ## add Rail Totals
+  toMIF <- rbindlist(list(
+    toMIF,
+    toMIF[grep("ES\\|Transport\\|(Pass|Freight)\\|Rail$", variable),
+          .(variable="ES|Transport|Rail",
+            unit="bn pkm/yr", value=sum(value)),
+          by=c("model", "scenario", "region", "period")],
+    toMIF[grep("FE\\|Transport\\|(Pass|Freight)\\|Rail$", variable),
+          .(variable="FE|Transport|Rail",
+            unit="EJ/yr", value=sum(value)),
+          by=c("model", "scenario", "region", "period")]), use.names = TRUE)
+
 
   if(!is.null(regionSubsetList)){
     toMIF <- toMIF[region %in% regionSubsetList]

--- a/R/reportEDGETransport.R
+++ b/R/reportEDGETransport.R
@@ -33,6 +33,7 @@ reportEDGETransport <- function(output_folder=".",
   RegionCode <- CountryCode <- cfg <- `.` <- sector <- subsector_L3 <- region <- year <- NULL
   subsector_L2 <- subsector_L1 <- aggr_mode <- vehicle_type <- det_veh <- aggr_nonmot <- NULL
   demand_F <- demand_EJ <- remind_rep <- V25 <- aggr_veh <- technology <- NULL
+  variable <- value <- NULL
 
   load(file.path(output_folder, "config.Rdata"))
 
@@ -227,6 +228,20 @@ reportEDGETransport <- function(output_folder=".",
     reportingESandFE(demand_km, "ES"),
     reportingESandFE(demand_ej, "FE")
   ))
+
+  ## add Road totals
+  road_tot_es <- toMIF[grep("ES\\|Transport\\|Pass\\|Road\\|[A-Za-z-]+$", variable),
+                       .(variable="ES|Transport|Pass|Road",
+                         unit="bn pkm/yr", value=sum(value)),
+                       by=c("model", "scenario", "region", "period")]
+  road_tot_fe <- toMIF[grep("FE\\|Transport\\|Pass\\|Road\\|[A-Za-z-]+$", variable),
+                       .(variable="FE|Transport|Pass|Road",
+                         unit="EJ/yr", value=sum(value)),
+                       by=c("model", "scenario", "region", "period")]
+
+  toMIF <- rbindlist(list(
+    toMIF, road_tot_es, road_tot_fe
+  ), use.names = TRUE)
 
   if(!is.null(regionSubsetList)){
     toMIF <- toMIF[region %in% regionSubsetList]

--- a/R/reportEDGETransport.R
+++ b/R/reportEDGETransport.R
@@ -246,6 +246,17 @@ reportEDGETransport <- function(output_folder=".",
             unit="EJ/yr", value=sum(value)),
           by=c("model", "scenario", "region", "period")]), use.names = TRUE)
 
+  toMIF <- rbindlist(list(
+    toMIF,
+    toMIF[grep("FE\\|Transport\\|(Pass|Freight)\\|Road$", variable),
+          .(variable="FE|Transport|Road",
+            unit="EJ/yr", value=sum(value)),
+          by=c("model", "scenario", "region", "period")],
+    toMIF[grep("FE\\|Transport\\|(Pass|Freight)\\|Rail$", variable),
+          .(variable="FE|Transport|Rail",
+            unit="EJ/yr", value=sum(value)),
+          by=c("model", "scenario", "region", "period")]), use.names = TRUE)
+
 
 
   if(!is.null(regionSubsetList)){

--- a/R/reportEDGETransport.R
+++ b/R/reportEDGETransport.R
@@ -246,28 +246,6 @@ reportEDGETransport <- function(output_folder=".",
             unit="EJ/yr", value=sum(value)),
           by=c("model", "scenario", "region", "period")]), use.names = TRUE)
 
-  toMIF <- rbindlist(list(
-    toMIF,
-    toMIF[grep("ES\\|Transport\\|(Pass|Freight)\\|Road$", variable),
-          .(variable="ES|Transport|Road",
-            unit="bn pkm/yr", value=sum(value)),
-          by=c("model", "scenario", "region", "period")],
-    toMIF[grep("FE\\|Transport\\|(Pass|Freight)\\|Road$", variable),
-          .(variable="FE|Transport|Road",
-            unit="EJ/yr", value=sum(value)),
-          by=c("model", "scenario", "region", "period")]), use.names = TRUE)
-
-  ## add Rail Totals
-  toMIF <- rbindlist(list(
-    toMIF,
-    toMIF[grep("ES\\|Transport\\|(Pass|Freight)\\|Rail$", variable),
-          .(variable="ES|Transport|Rail",
-            unit="bn pkm/yr", value=sum(value)),
-          by=c("model", "scenario", "region", "period")],
-    toMIF[grep("FE\\|Transport\\|(Pass|Freight)\\|Rail$", variable),
-          .(variable="FE|Transport|Rail",
-            unit="EJ/yr", value=sum(value)),
-          by=c("model", "scenario", "region", "period")]), use.names = TRUE)
 
 
   if(!is.null(regionSubsetList)){

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -663,11 +663,17 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
                  setNames(dimSums(prodFE[,,"segabio.fegas.tdbiogas"],dim=3),"FE|Other Sector|Gases|Biomass (EJ/yr)"),
                  setNames(dimSums(prodFE[,,"segafos.fegas.tdfosgas"],dim=3),"FE|Other Sector|Gases|Non-Biomass (EJ/yr)"),
                  setNames(dimSums(prodFE[,,c("seliqbio.fedie.tdbiodie", "seliqbio.fepet.tdbiopet")],dim=3),"FE|Transport|Liquids|Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,c("seliqfos.fedie.tdfosdie", "seliqfos.fepet.tdfospet")],dim=3),"FE|Transport|Liquids|Non-Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"segabio.fegat.tdbiogat"],dim=3),"FE|Transport|Gases|Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"segafos.fegat.tdfosgat"],dim=3),"FE|Transport|Gases|Non-Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,c("seliqfos.fedie.tdfosdie", "seliqfos.fepet.tdfospet")],dim=3),"FE|Transport|Liquids|Non-Biomass (EJ/yr)")
                  )
-      }
+    }
+
+    if("fegat" %in% fety && "segabio" %in% se_Gas){
+      tmp2 <- mbind(tmp2,
+                 setNames(dimSums(prodFE[,,"segabio.fegat.tdbiogat"],dim=3),"FE|Transport|Gases|Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"segafos.fegat.tdfosgat"],dim=3),"FE|Transport|Gases|Non-Biomass (EJ/yr)")
+                 )
+
+    }
   }
     
     tmp2 = mbind(tmp2,

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -661,7 +661,11 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
     if("segabio" %in% se_Gas){
       tmp2 <- mbind(tmp2,
                  setNames(dimSums(prodFE[,,"segabio.fegas.tdbiogas"],dim=3),"FE|Other Sector|Gases|Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"segafos.fegas.tdfosgas"],dim=3),"FE|Other Sector|Gases|Non-Biomass (EJ/yr)")
+                 setNames(dimSums(prodFE[,,"segafos.fegas.tdfosgas"],dim=3),"FE|Other Sector|Gases|Non-Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,c("seliqbio.fedie.tdbiodie", "seliqbio.fepet.tdbiopet")],dim=3),"FE|Transport|Liquids|Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,c("seliqfos.fedie.tdfosdie", "seliqfos.fepet.tdfospet")],dim=3),"FE|Transport|Liquids|Non-Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"segabio.fegat.tdbiogat"],dim=3),"FE|Transport|Gases|Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"segafos.fegat.tdfosgat"],dim=3),"FE|Transport|Gases|Non-Biomass (EJ/yr)"),
                  )
       }
   }


### PR DESCRIPTION
- Add variables required for the AR6 data template to the output file.
- Fix a unit error in the EDGE-T reporting, previously there were million pkm/tkm reported instead of billions.