### PR TITLE
bugfix with years inconsistencies across objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     gdxdt
 Encoding: UTF-8
 License: LGPL-3
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Suggests:
 	testthat,
 	sr15data

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -117,6 +117,7 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
   prodFE  <- prodFE[,y,]
   prodSE <- prodSE[,y,]
   vm_cesIO <- vm_cesIO[,y,]
+  v_prodEs <- v_prodEs[,y,]
   vm_otherFEdemand <- vm_otherFEdemand[,y,]
   v33_grindrock_onfield<- v33_grindrock_onfield[,y,]
   

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -268,7 +268,7 @@ reportTechnology <- function(gdx,output=NULL,regionSubsetList=NULL) {
   tmp_GLO <- new.magpie("GLO",getYears(tmp),magclass::getNames(tmp),fill=0)
 
   for (i2e in names(int2ext)){
-    tmp_GLO["GLO",,i2e] <- speed_aggregate(tmp[,,i2e],map,weight=output[map$region,,int2ext[i2e]])
+    tmp_GLO["GLO",,i2e] <- speed_aggregate(tmp[,,i2e],map,weight=output[map$region,,int2ext[[i2e]]])
   }
   tmp <- mbind(tmp,tmp_GLO)
 


### PR DESCRIPTION
two bugfixes
the first one restricts the number of years available in a magpie object.
For the second one, the simple ```[ ]``` was returning a list instead of a character vector. The double ```[[ ]]``` is necessary.