### PR TITLE
Added emissions from electricity and gases to EDGE-Transport. Bugfix in share of energy for transport calculation.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.167.0
-Date: 2020-06-24
+Version: 36.167.1
+Date: 2020-07-01
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -44,5 +44,5 @@ RoxygenNote: 7.1.0
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6668109790
+ValidationKey: 6670659924
 VignetteBuilder: knitr

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -875,6 +875,8 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
                * GtC_2_MtCO2, "Emi|CO2|Transport|Freight|Long Distance|Liquids (Mt CO2/yr)"),
       setNames(p35_share_sega_psm  * dimSums(mselect(v_emi,all_enty1=se_Gas,all_enty2="co2")[pe2se],dim=3)
                * GtC_2_MtCO2, "Emi|CO2|Transport|Pass|Short-Medium Distance|Gases (Mt CO2/yr)"),
+      setNames(p35_share_sega_fsm  * dimSums(mselect(v_emi,all_enty1=se_Gas,all_enty2="co2")[pe2se],dim=3)
+               * GtC_2_MtCO2, "Emi|CO2|Transport|Freight|Short-Medium Distance|Gases (Mt CO2/yr)"),
       setNames((p35_share_seel_psm  * dimSums(mselect(v_emi,all_enty1="seel",all_enty2="co2")[pe2se],dim=3)
         + p35_share_seh2_psm  * dimSums(mselect(v_emi,all_enty1="seh2",all_enty2="co2")[pe2se],dim=3)
         + p35_share_seliq_psm * dimSums(mselect(v_emi,all_enty1=se_Liq,all_enty2="co2")[pe2se],dim=3)


### PR DESCRIPTION
This pull request contains:

- a bugfix in how the share of secondary energy for transport is calculated (on SE demand instead of FE)

- emissions from electricity (direct use) and NG (direct use) in the system emissions calculation