### PR TITLE
Bugfixes on reportFE and reportTechnology

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     gdxdt
 Encoding: UTF-8
 License: LGPL-3
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Suggests:
 	testthat,
 	sr15data

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.167.0
-Date: 2020-06-24
+Version: 36.167.1
+Date: 2020-07-03
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -44,5 +44,5 @@ RoxygenNote: 7.1.1
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6668109790
+ValidationKey: 6671383266
 VignetteBuilder: knitr

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -117,6 +117,7 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
   prodFE  <- prodFE[,y,]
   prodSE <- prodSE[,y,]
   vm_cesIO <- vm_cesIO[,y,]
+  v_prodEs <- v_prodEs[,y,]
   vm_otherFEdemand <- vm_otherFEdemand[,y,]
   v33_grindrock_onfield<- v33_grindrock_onfield[,y,]
   

--- a/R/reportTechnology.R
+++ b/R/reportTechnology.R
@@ -268,7 +268,7 @@ reportTechnology <- function(gdx,output=NULL,regionSubsetList=NULL) {
   tmp_GLO <- new.magpie("GLO",getYears(tmp),magclass::getNames(tmp),fill=0)
 
   for (i2e in names(int2ext)){
-    tmp_GLO["GLO",,i2e] <- speed_aggregate(tmp[,,i2e],map,weight=output[map$region,,int2ext[i2e]])
+    tmp_GLO["GLO",,i2e] <- speed_aggregate(tmp[,,i2e],map,weight=output[map$region,,int2ext[[i2e]]])
   }
   tmp <- mbind(tmp,tmp_GLO)
 


### PR DESCRIPTION
This PR contains two bugfixes:

- fixed year inconsistency for  v_prodEs[,y,]

- the object int2ext[i2e] was giving back a list element, and not a character vector. using "[[" instead of "[" was therefore necessary