### PR TITLE
Add trailing semicolon to EDGE-Transport reporting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.168.1
+Version: 36.168.2
 Date: 2020-07-14
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
@@ -44,5 +44,5 @@ RoxygenNote: 7.1.1
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6675546217
+ValidationKey: 6675564674
 VignetteBuilder: knitr

--- a/R/reportEDGETransport.R
+++ b/R/reportEDGETransport.R
@@ -515,10 +515,9 @@ reportEDGETransport <- function(output_folder=".",
   }
 
   toMIF <- data.table::dcast(toMIF, ... ~ period, value.var="value")
-  if(length(toMIF) < length(miffile)){
-    toMIF[, V25 := ""]
-  }
 
-  fwrite(toMIF, name_mif, append=T, sep=";")
+  EOL <- if (.Platform$OS.type=="windows") ";\r\n" else ";\n"
+
+  fwrite(toMIF, name_mif, append=T, sep=";", eol=EOL)
   deletePlus(name_mif, writemif=T)
 }


### PR DESCRIPTION
This is required to comply with REMIND's default output (MIF) format for the addition of EDGE-Transport variables.