### PR TITLE
fix duplicate variable names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.168.0
-Date: 2020-07-07
+Version: 36.168.1
+Date: 2020-07-15
 Author: Anastasis Giannousakis, Michaja Pehl
 Maintainer: Anastasis Giannousakis <giannou@pik-potsdam.de>
 Description: Contains the REMIND-specific routines for data and model output manipulation.
@@ -44,5 +44,5 @@ RoxygenNote: 7.1.1
 Suggests:
 	testthat,
 	sr15data
-ValidationKey: 6672996000
+ValidationKey: 6675907898
 VignetteBuilder: knitr

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -192,34 +192,55 @@ reportCrossVariables <- function(gdx,output=NULL,regionSubsetList=NULL){
   }
   
   # variables that are calculated for all regions including GLO in the same way
-  tmp <- mbind(tmp,setNames(
-                  output[,,"FE (EJ/yr)"] * 1000
-                / output[,,"GDP|MER (billion US$2005/yr)"],           "Intensity|GDP|Final Energy (MJ/US$2005)"))
-  tmp <- mbind(tmp,setNames(
-                  output[,,"GDP|MER (billion US$2005/yr)"] 
-                / output[,,"FE (EJ/yr)"],           "Productivity|GDP|MER|Final Energy (US$2005/GJ)"))
-  tmp <- mbind(tmp,setNames(
-                  output[,,"GDP|PPP (billion US$2005/yr)"] 
-                / output[,,"FE (EJ/yr)"],           "Productivity|GDP|PPP|Final Energy (US$2005/GJ)"))
-  tmp <- mbind(tmp,setNames(
-                  (output[,,"Emi|CO2|Fossil Fuels and Industry (Mt CO2/yr)"] - output[,,"Emi|CO2|Fossil Fuels and Industry|Cement process (Mt CO2/yr)"])
-                / output[,,"FE (EJ/yr)"],                 "Intensity|Final Energy|CO2 (Mt CO2/EJ)"))
-  tmp <- mbind(tmp,setNames(
-                  output[,,"Emi|GHGtot (Mt CO2-equiv/yr)"]
-                / output[,,"GDP|MER (billion US$2005/yr)"],                 "Intensity|GDP|CO2 (Mt CO2-equiv/US$2005)"))
-  tmp <- mbind(tmp,setNames(
-                  output[,,"Emi|GHGtot (Mt CO2-equiv/yr)"]
-                / output[,,"FE (EJ/yr)"],                 "Intensity|Final Energy|CO2 (Mt CO2-equiv/EJ)"))
-  tmp <- mbind(tmp,setNames(
-                  output[,,"GDP|MER (billion US$2005/yr)"]
-                / output[,,"Population (million)"],                 "GDP|per capita|MER (kUS$2005/per capita)"))
-  tmp <- mbind(tmp,setNames(
-                  output[,,"GDP|PPP (billion US$2005/yr)"]
-                / output[,,"Population (million)"],                 "GDP|per capita|PPP (kUS$2005/per capita)")) 
-  tmp <- mbind(tmp,setNames(
-    output[,,"Welfare|Real and undiscounted|Yearly (arbitrary unit/yr)"]
-    / output[,,"Population (million)"],                 "Welfare|per capita|Real and undiscounted|Yearly (arbitrary unit/yr)")) 
-
+  tmp <- mbind(
+    tmp,
+    
+    setNames(
+        output[,,"FE (EJ/yr)"] * 1000
+      / output[,,"GDP|MER (billion US$2005/yr)"],
+      "Intensity|GDP|Final Energy (MJ/US$2005)"),
+    
+    setNames(
+        output[,,"GDP|MER (billion US$2005/yr)"] 
+      / output[,,"FE (EJ/yr)"],
+      "Productivity|GDP|MER|Final Energy (US$2005/GJ)"),
+    
+    setNames(
+        output[,,"GDP|PPP (billion US$2005/yr)"] 
+      / output[,,"FE (EJ/yr)"],
+      "Productivity|GDP|PPP|Final Energy (US$2005/GJ)"),
+    
+    setNames(
+        ( output[,,"Emi|CO2|Fossil Fuels and Industry (Mt CO2/yr)"] 
+        - output[,,"Emi|CO2|Fossil Fuels and Industry|Cement process (Mt CO2/yr)"]
+        )
+      / output[,,"FE (EJ/yr)"],
+      "Intensity|Final Energy|CO2 (Mt CO2/EJ)"),
+    
+    setNames(
+        output[,,"Emi|GHGtot (Mt CO2-equiv/yr)"]
+      / output[,,"FE (EJ/yr)"],
+      "Intensity|Final Energy|GHG (Mt CO2-equiv/EJ)"),
+    
+    setNames(
+        output[,,"Emi|GHGtot (Mt CO2-equiv/yr)"]
+      / output[,,"GDP|MER (billion US$2005/yr)"],
+      "Intensity|GDP|GHG (Mt CO2-equiv/US$2005)"),
+    
+    setNames(
+        output[,,"GDP|MER (billion US$2005/yr)"]
+      / output[,,"Population (million)"],
+      "GDP|per capita|MER (kUS$2005/per capita)"),
+    
+    setNames(
+        output[,,"GDP|PPP (billion US$2005/yr)"]
+      / output[,,"Population (million)"],
+      "GDP|per capita|PPP (kUS$2005/per capita)"),
+    
+    setNames(
+        output[,,"Welfare|Real and undiscounted|Yearly (arbitrary unit/yr)"]
+      / output[,,"Population (million)"],
+      "Welfare|per capita|Real and undiscounted|Yearly (arbitrary unit/yr)"))
   
   # Energy shares
   tmp <- mbind(tmp,setNames(       # assume 8% for transmission losses and autoconsumption of power plants


### PR DESCRIPTION
- `Intensity|Final Energy|CO2` is reported twice, once with `Mt CO2/EJ`,
  once with `Mt CO2-equiv/EJ`
- both variables differ in their calculation
- `Intensity|Final Energy|CO2` with `Mt CO2-equiv/EJ` is renamed
  `Intensity|Final Energy|GHG`

/close #64 