### PR TITLE
Correctly report biomass shares in complex and EDGE-T Liquids

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6704034755'
+ValidationKey: '6704053288'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind: The REMIND R package",
-  "version": "36.173.5",
+  "version": "36.173.6",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.173.5
+Version: 36.173.6
 Date: 2020-09-28
 Authors@R: as.person(c(
 	   "Anastasis Giannousakis <giannou@pik-potsdam.de> [aut,cre]",

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -143,8 +143,8 @@ reportCrossVariables <- function(gdx,output=NULL,regionSubsetList=NULL){
   if(tran_mod == "complex"){
       tmp <- mbind(tmp,setNames(
                            output[r,,"FE|Transport|Pass|Road|LDV|Liquids (EJ/yr)"] 
-                           * output[r,,"SE|Liquids|Biomass (EJ/yr)"]
-                           / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Pass|Road|LDV|Liquids|Biomass (EJ/yr)"))
+                           * output[r,,"FE|Transport|Pass|Liquids|Biomass (EJ/yr)"]
+                           / output[r,,"FE|Transport|Pass|Liquids (EJ/yr)"],                     "FE|Transport|Pass|Road|LDV|Liquids|Biomass (EJ/yr)"))
       tmp <- mbind(tmp,setNames(
                            output[r,,"FE|Transport|Pass|Road|LDV|Liquids (EJ/yr)"] 
                            * output[r,,"SE|Liquids|Coal (EJ/yr)"]

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -106,10 +106,6 @@ reportCrossVariables <- function(gdx,output=NULL,regionSubsetList=NULL){
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Freight|Liquids|Oil (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
                    output[r,,"FE|Transport|Freight|Liquids (EJ/yr)"]
-                 * output[r,,"SE|Liquids|Biomass (EJ/yr)"]
-                 / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Freight|Liquids|Biomass (EJ/yr)"))
-  tmp <- mbind(tmp,setNames(
-                   output[r,,"FE|Transport|Freight|Liquids (EJ/yr)"]
                  * output[r,,"SE|Liquids|Coal (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Freight|Liquids|Coal (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
@@ -133,10 +129,6 @@ reportCrossVariables <- function(gdx,output=NULL,regionSubsetList=NULL){
                  output[r,,"FE|Transport|Pass|Liquids (EJ/yr)"]
                  * output[r,,"SE|Liquids|Oil (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Pass|Liquids|Oil (EJ/yr)"))
-  tmp <- mbind(tmp,setNames(
-                 output[r,,"FE|Transport|Pass|Liquids (EJ/yr)"]
-                 * output[r,,"SE|Liquids|Biomass (EJ/yr)"]
-                 / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Pass|Liquids|Biomass (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
                  output[r,,"FE|Transport|Pass|Liquids (EJ/yr)"]
                  * output[r,,"SE|Liquids|Coal (EJ/yr)"]

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -561,10 +561,13 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
 
     demFE <- readGDX(gdx,name=c("v_demFe","vm_demFe"),field="l",restore_zeros=FALSE,format="first_found")*TWa_2_EJ
     demFE <- demFE[fe2ue]
+    demFEdieTrsp <- dimSums(demFE[,, "fedie"], dim=3) - vm_otherFEdemand[,,'fedie']
 
     tmp1 <- mbind(tmp1,
-                  setNames(dimSums(demFE[,, "fepet"],dim=3),             "FE|Transport|Pass|Liquids (EJ/yr)" ),
-                  setNames(dimSums(demFE[,, "fedie"] - vm_otherFEdemand[,,'fedie'],dim=3),             "FE|Transport|Freight|Liquids (EJ/yr)" ),
+                  setNames(dimSums(demFE[,, "fepet"], dim=3) + demFEdieTrsp  * p35_pass_FE_share_transp,
+                           "FE|Transport|Pass|Liquids (EJ/yr)" ),
+                  setNames(demFEdieTrsp * (1-p35_pass_FE_share_transp),
+                           "FE|Transport|Freight|Liquids (EJ/yr)" ),
                   setNames(dimSums(demFE[,, "feh2t"],dim=3),             "FE|Transport|Pass|Hydrogen (EJ/yr)" ),
                   setNames(dimSums(demFE[,, "feelt"],dim=3),             "FE|Transport|Pass|Electricity (EJ/yr)" ),
                   setNames(dimSums(demFE[setTrainEl],dim=3),             "FE|Transport|Pass|Train|Electricity (EJ/yr)" ),
@@ -679,14 +682,34 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
                  setNames(tmp1[,,"FE|Buildings|Heat (EJ/yr)"] + tmp1[,,"FE|Industry|Heat (EJ/yr)"],"FE|Other Sector|Heat (EJ/yr)")
                  )
     if("segabio" %in% se_Gas){
+      ## Bioshare in FEDIE and FEPET
+      fedie_bioshare <- dimSums(prodFE[,,"seliqbio.fedie.tdbiodie"] /
+                                (prodFE[,,"seliqbio.fedie.tdbiodie"] +
+                                 prodFE[,, "seliqfos.fedie.tdfosdie"]),dim=3)
+      fepet_bioshare <- dimSums(prodFE[,,"seliqbio.fepet.tdbiopet"] /
+                                (prodFE[,,"seliqbio.fepet.tdbiopet"] +
+                                 prodFE[,, "seliqfos.fepet.tdfospet"]),dim=3)
       tmp2 <- mbind(tmp2,
                  setNames(dimSums(prodFE[,,"segabio.fegas.tdbiogas"],dim=3),"FE|Other Sector|Gases|Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"segafos.fegas.tdfosgas"],dim=3),"FE|Other Sector|Gases|Non-Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,c("seliqbio.fedie.tdbiodie", "seliqbio.fepet.tdbiopet")],dim=3),"FE|Transport|Liquids|Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,c("seliqfos.fedie.tdfosdie", "seliqfos.fepet.tdfospet")],dim=3),"FE|Transport|Liquids|Non-Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"seliqbio.fedie.tdbiodie"],dim=3),"FE|Transport|Freight|Liquids|Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,"seliqbio.fepet.tdbiopet"],dim=3),"FE|Transport|Pass|Liquids|Biomass (EJ/yr)")
-                 )
+                 setNames(dimSums(prodFE[,,"segafos.fegas.tdfosgas"],dim=3),"FE|Other Sector|Gases|Non-Biomass (EJ/yr)"))
+      if(tran_mod == "edge_esm"){
+        p35_pass_FE_share_transp <- dimSums(vm_demFeForEs_trnsp[,,"esdie_pass_",pmatch=TRUE], dim=3) /
+          dimSums(vm_demFeForEs_trnsp[,,"esdie_",pmatch=TRUE], dim=3)
+      }
+
+      tmp2 <- mbind(
+        tmp2,
+        setNames((dimSums(prodFE[,,"fedie"], dim=3) - vm_otherFEdemand[,,'fedie'])* fedie_bioshare * p35_pass_FE_share_transp +
+                 dimSums(prodFE[,,"fepet"], dim=3) * fepet_bioshare,
+                 "FE|Transport|Pass|Liquids|Biomass (EJ/yr)"),
+        setNames((dimSums(prodFE[,,"fedie"], dim=3) - vm_otherFEdemand[,,'fedie']) * (1-p35_pass_FE_share_transp) * fedie_bioshare,
+                 "FE|Transport|Freight|Liquids|Biomass (EJ/yr)"))
+      tmp2 <- mbind(tmp2,
+                    setNames(
+                      tmp2[,,"FE|Transport|Pass|Liquids|Biomass (EJ/yr)"] +
+                      tmp2[,,"FE|Transport|Freight|Liquids|Biomass (EJ/yr)"],
+                      "FE|Transport|Liquids|Biomass (EJ/yr)"
+                    ))
     }
 
     if("fegat" %in% fety && "segabio" %in% se_Gas){

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -683,7 +683,9 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
                  setNames(dimSums(prodFE[,,"segabio.fegas.tdbiogas"],dim=3),"FE|Other Sector|Gases|Biomass (EJ/yr)"),
                  setNames(dimSums(prodFE[,,"segafos.fegas.tdfosgas"],dim=3),"FE|Other Sector|Gases|Non-Biomass (EJ/yr)"),
                  setNames(dimSums(prodFE[,,c("seliqbio.fedie.tdbiodie", "seliqbio.fepet.tdbiopet")],dim=3),"FE|Transport|Liquids|Biomass (EJ/yr)"),
-                 setNames(dimSums(prodFE[,,c("seliqfos.fedie.tdfosdie", "seliqfos.fepet.tdfospet")],dim=3),"FE|Transport|Liquids|Non-Biomass (EJ/yr)")
+                 setNames(dimSums(prodFE[,,c("seliqfos.fedie.tdfosdie", "seliqfos.fepet.tdfospet")],dim=3),"FE|Transport|Liquids|Non-Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"seliqbio.fedie.tdbiodie"],dim=3),"FE|Transport|Freight|Liquids|Biomass (EJ/yr)"),
+                 setNames(dimSums(prodFE[,,"seliqbio.fepet.tdbiopet"],dim=3),"FE|Transport|Pass|Liquids|Biomass (EJ/yr)")
                  )
     }
 


### PR DESCRIPTION
Biomass quantities have previously been derived from biomass share in SE|Liquids, but the biofuels can be distributed quite unevenly across sectors. Hence, the specific quantities (`seliqbio.fepet.tdbiopet` etc) have to be reported. 