### PR TITLE
include new parameters in convergenceCheck script

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,7 +1,8 @@
-ValidationKey: '6718449241'
+ValidationKey: '6720063500'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'
+- ‘qpdf’ is needed for checks on size reduction of PDFs
 AcceptedNotes:
 - Imports includes .* non-default packages.
 - unable to verify current time

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind: The REMIND R package",
-  "version": "36.177.1",
+  "version": "36.178.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.177.1
-Date: 2020-11-05
+Version: 36.178.0
+Date: 2020-11-09
 Authors@R: as.person(c(
 	   "Anastasis Giannousakis <giannou@pik-potsdam.de> [aut,cre]",
 	   "Michaja Pehl [aut]"))

--- a/R/convergenceCheck.R
+++ b/R/convergenceCheck.R
@@ -24,7 +24,7 @@
 convergenceCheck <- function(gdx,y=c(seq(2005,2060,5),seq(2070,2100,10)),file="convergenceCheck.pdf") {
 
 ##################### read in data ############################################
-iter      <- readGDX(gdx,"cm_iteration_max")   # maximal numer of iterations
+iter      <- readGDX(gdx,"cm_iteration_max")   # maximal number of iterations
 iter      <- c(as.character(1:iter))
 deltarev  <- readGDX(gdx,name=c("p21_deltarev","pm_deltarev"),format="first_found")[,,iter]
 
@@ -34,12 +34,14 @@ p21_taxrevCCS_iter        <- readGDX(gdx,c("p21_taxrevCCS_iter"),format="first_f
 p21_taxrevNetNegEmi_iter  <- readGDX(gdx,c("p21_taxrevNetNegEmi_iter"),format="first_found")[,y,iter]
 p21_taxrevFEtrans_iter    <- readGDX(gdx,c("p21_taxrevFEtrans_iter"),format="first_found")[,y,iter]
 p21_taxrevFEBuildInd_iter <- readGDX(gdx,c("p21_taxrevFEBuildInd_iter"),format="first_found")[,y,iter]
+p21_taxrevFE_Es_iter      <- readGDX(gdx,c("p21_taxrevFE_Es_iter"),format="first_found")[,y,iter]
 p21_taxrevResEx_iter      <- readGDX(gdx,c("p21_taxrevResEx_iter"),format="first_found")[,y,iter]
 p21_taxrevPE2SE_iter      <- readGDX(gdx,c("p21_taxrevPE2SE_iter"),format="first_found")[,y,iter]
 p21_taxrevXport_iter      <- readGDX(gdx,c("p21_taxrevXport_iter"),format="first_found")[,y,iter]
 p21_taxrevSO2_iter        <- readGDX(gdx,c("p21_taxrevSO2_iter"),format="first_found")[,y,iter]
 p21_taxrevBio_iter        <- readGDX(gdx,c("p21_taxrevBio_iter"),format="first_found")[,y,iter]
-
+p21_implicitDiscRate_iter <- readGDX(gdx,c("p21_implicitDiscRate_iter"),format="first_found")[,y,iter]
+p21_taxrevFlex_iter       <- readGDX(gdx,c("p21_taxrevFlex_iter"),format="first_found")[,y,iter]
 ###############################################################################
 
 ################## open output-pdf ############################################
@@ -103,6 +105,15 @@ p <- magpie2ggplot2(p21_taxrevFEBuildInd_iter,color="Data1",color_pal=col,ncol=3
                     ylab='p21_taxrevFEBuildInd_iter',show_grid=TRUE,legend_ncol=4)
 swfigure(sw,print,p,sw_option="height=10,width=9")
 
+swlatex(sw,"\\subsection{taxrevFE_Es}")
+p <- magpie2ggplot2(p21_taxrevFE_Es_iter,xaxis="Data1",ncol=3,color="Year",color_pal=col_y,asDate=FALSE,
+                    ylab='p21_taxrevFE_Es_iter',xlab="iteration",show_grid=TRUE)
+swfigure(sw,print,p,sw_option="height=10,width=9")
+
+p <- magpie2ggplot2(p21_taxrevFE_Es_iter,color="Data1",color_pal=col,ncol=3,group=NULL,
+                    ylab='p21_taxrevFE_Es_iter',show_grid=TRUE,legend_ncol=4)
+swfigure(sw,print,p,sw_option="height=10,width=9")
+
 swlatex(sw,"\\subsection{taxrevResEx}")
 p <- magpie2ggplot2(p21_taxrevResEx_iter,xaxis="Data1",ncol=3,color="Year",color_pal=col_y,asDate=FALSE,
                     ylab='p21_taxrevResEx_iter',xlab="iteration",show_grid=TRUE)
@@ -148,6 +159,23 @@ p <- magpie2ggplot2(p21_taxrevBio_iter,color="Data1",color_pal=col,ncol=3,group=
                     ylab='p21_taxrevBio_iter',show_grid=TRUE,legend_ncol=4)
 swfigure(sw,print,p,sw_option="height=10,width=9")
 
+swlatex(sw,"\\subsection{implicitDiscRate}")
+p <- magpie2ggplot2(p21_implicitDiscRate_iter,xaxis="Data1",ncol=3,color="Year",color_pal=col_y,asDate=FALSE,
+                    ylab='p21_implicitDiscRate_iter',xlab="iteration",show_grid=TRUE)
+swfigure(sw,print,p,sw_option="height=10,width=9")
+
+p <- magpie2ggplot2(p21_implicitDiscRate_iter,color="Data1",color_pal=col,ncol=3,group=NULL,
+                    ylab='p21_implicitDiscRate_iter',show_grid=TRUE,legend_ncol=4)
+swfigure(sw,print,p,sw_option="height=10,width=9")
+
+swlatex(sw,"\\subsection{taxrevFlex}")
+p <- magpie2ggplot2(p21_taxrevFlex_iter,xaxis="Data1",ncol=3,color="Year",color_pal=col_y,asDate=FALSE,
+                    ylab='p21_taxrevFlex_iter',xlab="iteration",show_grid=TRUE)
+swfigure(sw,print,p,sw_option="height=10,width=9")
+
+p <- magpie2ggplot2(p21_taxrevFlex_iter,color="Data1",color_pal=col,ncol=3,group=NULL,
+                    ylab='p21_taxrevFlex_iter',show_grid=TRUE,legend_ncol=4)
+swfigure(sw,print,p,sw_option="height=10,width=9")
 
 ###############################################################################
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package
 
-R package **remind**, version **36.177.0**
+R package **remind**, version **36.178.0**
 
   
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **remind** in publications use:
 
-Giannousakis A, Pehl M (2020). _remind: The REMIND R package_. R package version 36.174.1.
+Giannousakis A, Pehl M (2020). _remind: The REMIND R package_. R package version 36.178.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind: The REMIND R package},
   author = {Anastasis Giannousakis and Michaja Pehl},
   year = {2020},
-  note = {R package version 36.174.1},
+  note = {R package version 36.178.0},
 }
 ```
 


### PR DESCRIPTION
the following parameters appearing in "equations.gms" of module 21 were not included, because I could not find them in fulldata.gdx: 
- p21_taxrevCO2luc
- pm_costSubsidizeLearning