### PR TITLE
Temporary fix for emission factors to correctly report Supply Variables to AR6

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6720629616'
+ValidationKey: '6723180736'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind: The REMIND R package",
-  "version": "36.179.1",
+  "version": "36.179.2",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.179.1
-Date: 2020-11-10
+Version: 36.179.2
+Date: 2020-11-17
 Authors@R: as.person(c(
 	   "Anastasis Giannousakis <giannou@pik-potsdam.de> [aut,cre]",
 	   "Michaja Pehl [aut]"))

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -129,6 +129,14 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
   p_share_seh2_s    <- readGDX(gdx, "p_share_seh2_s")
   p_share_seliq_s   <- readGDX(gdx, "p_share_seliq_s")
   p_ef_dem          <- readGDX(gdx, "p_ef_dem")
+  ## temporary workaround to test reverted emission factors for the AR6 reporting
+  p_ef_dem[,, "fedie"] = 69.3;
+  p_ef_dem[,, "fehos"] = 69.3;
+  p_ef_dem[,, "fepet"] = 68.5;
+  p_ef_dem[,, "fegas"] = 50.3;
+  p_ef_dem[,, "fegat"] = 50.3;
+  p_ef_dem[,, "fesos"] = 90.5;
+
   p_bioshare        <- readGDX(gdx, "p_bioshare")
   ppfen_stat   <- readGDX(gdx,c("ppfen_stationary_dyn38","ppfen_stationary_dyn28","ppfen_stationary"),format="first_found", react = "silent")
   


### PR DESCRIPTION
For details on the problem, see here:
https://github.com/remindmodel/development_issues/issues/20

Instead of reading emission factor from the GDX, as a temporary workaround we set them directly in `reportEmi.R`, consistent with the values before commit https://github.com/remindmodel/remind/commit/934783750931eb2b3e6c64b5b65b139522d4b70a
