### PR TITLE
Added transport gases in summary and compare scenarios plot.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6724053000'
+ValidationKey: '6724433386'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind: The REMIND R package",
-  "version": "36.180.0",
+  "version": "36.180.1",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.180.0
-Date: 2020-11-19
+Version: 36.180.1
+Date: 2020-11-20
 Authors@R: as.person(c(
 	   "Anastasis Giannousakis <giannou@pik-potsdam.de> [aut,cre]",
 	   "Michaja Pehl [aut]"))

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -588,7 +588,8 @@ compareScenarios <- function(mif, hist,
   items<- c (
     "FE|Transport|Electricity (EJ/yr)",
     "FE|Transport|Hydrogen (EJ/yr)",
-    "FE|Transport|Liquids (EJ/yr)"
+    "FE|Transport|Liquids (EJ/yr)",
+    "FE|Transport|Gases (EJ/yr)"
   )
 
   var <- data[,,intersect(items,getNames(data,dim=3))]

--- a/R/validationSummary.R
+++ b/R/validationSummary.R
@@ -192,14 +192,12 @@ validationSummary <- function(gdx, hist, reportfile=NULL, outfile="validationSum
   swlatex(sw,"\\subsection{FE Transport}")
   
   var.tot <-"FE|Transport (EJ/yr)"
-  vars <- c("FE|Transport|Liquids|Oil (EJ/yr)",
-            "FE|Transport|Liquids|Coal (EJ/yr)",
-            "FE|Transport|Liquids|Biomass (EJ/yr)",
-            #"FE|Transport|Gases (EJ/yr)",
+  vars <- c("FE|Transport|Liquids (EJ/yr)",
+            "FE|Transport|Gases (EJ/yr)",
             "FE|Transport|Electricity (EJ/yr)",
             "FE|Transport|Hydrogen (EJ/yr)"
   )
-  
+
   p <- mipArea(data["GLO",,vars], total = data["GLO",,var.tot]) + theme(legend.position="none")
   swfigure(sw,print,p,fig.width=0.5)
   


### PR DESCRIPTION
Addition of gases in transport in plots. Calculates the total FE in transport as sum of liquids+gases+hydrogen+electricity (instead of misleading for the moment sub-categories of liquids)