### PR TITLE
Fix FE synfuel reporting transport

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6724433386'
+ValidationKey: '6725537378'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind: The REMIND R package",
-  "version": "36.180.1",
+  "version": "36.180.2",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.180.1
-Date: 2020-11-20
+Version: 36.180.2
+Date: 2020-11-23
 Authors@R: as.person(c(
 	   "Anastasis Giannousakis <giannou@pik-potsdam.de> [aut,cre]",
 	   "Michaja Pehl [aut]"))

--- a/R/reportCrossVariables.R
+++ b/R/reportCrossVariables.R
@@ -109,10 +109,6 @@ reportCrossVariables <- function(gdx,output=NULL,regionSubsetList=NULL){
                  * output[r,,"SE|Liquids|Coal (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Freight|Liquids|Coal (EJ/yr)"))
   tmp <- mbind(tmp,setNames(
-                   output[r,,"FE|Transport|Freight|Liquids (EJ/yr)"]
-                 * output[r,,"SE|Liquids|Hydrogen (EJ/yr)"]
-                 / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Freight|Liquids|Hydrogen (EJ/yr)"))
-  tmp <- mbind(tmp,setNames(
                    output[r,,"FE|Transport|Liquids (EJ/yr)"] 
                  * output[r,,"SE|Liquids|Coal (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Liquids|Coal (EJ/yr)"))
@@ -120,11 +116,6 @@ reportCrossVariables <- function(gdx,output=NULL,regionSubsetList=NULL){
                    output[r,,"FE|Transport|Liquids (EJ/yr)"] 
                  * output[r,,"SE|Liquids|Oil (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Liquids|Oil (EJ/yr)"))
-  tmp <- mbind(tmp,setNames(
-                   output[r,,"FE|Transport|Liquids (EJ/yr)"]
-                 * output[r,,"SE|Liquids|Hydrogen (EJ/yr)"]
-                 / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Liquids|Hydrogen (EJ/yr)"))
-
   tmp <- mbind(tmp,setNames(
                  output[r,,"FE|Transport|Pass|Liquids (EJ/yr)"]
                  * output[r,,"SE|Liquids|Oil (EJ/yr)"]
@@ -134,10 +125,6 @@ reportCrossVariables <- function(gdx,output=NULL,regionSubsetList=NULL){
                  * output[r,,"SE|Liquids|Coal (EJ/yr)"]
                  / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Pass|Liquids|Coal (EJ/yr)"))
 
-  tmp <- mbind(tmp,setNames(
-                     output[r,,"FE|Transport|Pass|Liquids (EJ/yr)"]
-                     * output[r,,"SE|Liquids|Hydrogen (EJ/yr)"]
-                     / output[r,,"SE|Liquids (EJ/yr)"],                     "FE|Transport|Pass|Liquids|Hydrogen (EJ/yr)"))
 
 
   if(tran_mod == "complex"){

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -802,6 +802,70 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
                 setNames(tmp4[,,"FE (EJ/yr)"] - tmp4[,,"FE|+|Electricity (EJ/yr)"] - tmp4[,,"FE|+|Heat (EJ/yr)"], "FE|Fuels (EJ/yr)") 
   )
   out <- tmp5
+  
+  
+  ### FS: add new FE sectoral synfuel/biomass/fossil reporting
+  #( taking into account that the proportion of seliqfos and seliqbio flows may be different across sectors)
+  
+  ### disclaimer: (!) SE synfuels in REMIND normal are temporarily are part of segafos/seliqfos (this is differnet in REMIND-EU!)
+  
+  
+  # calculate synfuel share in SE seliqbio
+  
+  # only if CCU is on
+  if ("MeOH" %in% getNames(prodSE, dim=3)) {
+    vm_prodSE <- readGDX(gdx,name=c("vm_prodSe","v_seprod"),field="l",restore_zeros=FALSE,format="first_found")
+    
+    p_share_synfuel_liq <- collapseNames(vm_prodSE[,,"seliqfos.MeOH"] / dimSums(mselect(vm_prodSE, all_enty1="seliqfos"), dim=3))
+    p_share_synfuel_gas <- vm_prodSE[,,"h22ch4"] / dimSums(mselect(vm_prodSE, all_enty1="segafos"), dim=3)
+    
+    tmp8 <- NULL
+    
+    
+    tmp8 <- mbind(tmp8,
+                  setNames(p_share_synfuel_liq * collapseNames(prodFE[,,"seliqfos.fepet.tdfospet"]), 
+                           "FE|Transport|Liquids|LDV|Synthetic|New Reporting (EJ/yr)"),
+                  setNames(p_share_synfuel_liq * collapseNames(prodFE[,,"seliqfos.fedie.tdfosdie"]), 
+                           "FE|Transport|Liquids|HDV|Synthetic|New Reporting (EJ/yr)"),
+                  setNames(p_share_synfuel_liq * collapseNames(dimSums(prodFE[,,c("tdfospet","tdfosdie")], dim=3)), 
+                           "FE|Transport|Liquids|Synthetic|New Reporting (EJ/yr)"),
+                  setNames(collapseNames(prodFE[,,"seliqbio.fepet.tdbiopet"]), 
+                           "FE|Transport|Liquids|LDV|Biomass|New Reporting (EJ/yr)"),
+                  setNames(collapseNames(prodFE[,,"seliqbio.fedie.tdbiodie"]), 
+                           "FE|Transport|Liquids|HDV|Biomass|New Reporting (EJ/yr)"),
+                  setNames(collapseNames(dimSums(prodFE[,,c("tdbiopet","tdbiodie")], dim=3)), 
+                           "FE|Transport|Liquids|Biomass|New Reporting (EJ/yr)"),   
+                  setNames((1-p_share_synfuel_liq) * collapseNames(prodFE[,,"seliqfos.fepet.tdfospet"]), 
+                           "FE|Transport|Liquids|LDV|Fossil|New Reporting (EJ/yr)"),
+                  setNames((1-p_share_synfuel_liq) * collapseNames(prodFE[,,"seliqfos.fedie.tdfosdie"]), 
+                           "FE|Transport|Liquids|HDV|Fossil|New Reporting (EJ/yr)"),
+                  setNames((1-p_share_synfuel_liq) * collapseNames(dimSums(prodFE[,,c("tdfospet","tdfosdie")], dim=3)), 
+                           "FE|Transport|Liquids|Fossil|New Reporting (EJ/yr)"))
+    
+    if ("fegat" %in% getNames(prodFE, dim=2)) {
+      tmp8 <- mbind(tmp8,
+                    setNames(p_share_synfuel_liq * collapseNames(dimSums(prodFE[,,c("tdfosgat")], dim=3)), 
+                             "FE|Transport|Gases|Synthetic|New Reporting (EJ/yr)"),
+                    setNames(collapseNames(dimSums(prodFE[,,c("tdbiogat")], dim=3)), 
+                             "FE|Transport|Gases|Biomass|New Reporting (EJ/yr)"),   
+                    setNames((1-p_share_synfuel_liq) * collapseNames(dimSums(prodFE[,,c("tdfosgat")], dim=3)), 
+                             "FE|Transport|Gases|Fossil|New Reporting (EJ/yr)"))
+      
+    }
+    
+    out <- mbind(out, tmp8)
+  }
+ 
+  
+  
+
+
+ 
+
+  
+
+  
+  
   # add global values
   out <- mbind(out,dimSums(out,dim=1))
   # add other region aggregations

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The REMIND R package
 
-R package **remind**, version **36.180.0**
+R package **remind**, version **36.180.2**
 
   
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **remind** in publications use:
 
-Giannousakis A, Pehl M (2020). _remind: The REMIND R package_. R package version 36.179.5.
+Giannousakis A, Pehl M (2020). _remind: The REMIND R package_. R package version 36.180.2.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind: The REMIND R package},
   author = {Anastasis Giannousakis and Michaja Pehl},
   year = {2020},
-  note = {R package version 36.179.5},
+  note = {R package version 36.180.2},
 }
 ```
 


### PR DESCRIPTION
This improves the calculation of FE synfuel variables in the reporting. New variables are introduced "FE|Transport|Liquids|LDV|Synthetic|New Reporting (EJ/yr)" ..., distinguishing between synfuels, biofuels and fossil fuels on FE transport liquids and gases level for LDV and HDV. The old transport synfuel variables were removed. 