### PR TITLE
fix energy supply emissions w/ CCU

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.182.0
-Date: 2021-01-07
+Version: 36.182.1
+Date: 2021-01-11
 Authors@R: as.person(c(
 	   "Anastasis Giannousakis <giannou@pik-potsdam.de> [aut,cre]",
 	   "Michaja Pehl [aut]"))
@@ -45,6 +45,7 @@ Encoding: UTF-8
 License: LGPL-3
 RoxygenNote: 7.1.1
 Suggests:
-	testthat,
-	sr15data
+    testthat,
+    sr15data,
+    covr
 VignetteBuilder: knitr

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The REMIND R package
 
-R package **remind**, version **36.181.1**
+R package **remind**, version **36.182.1**
 
-  
+[![CRAN status](https://www.r-pkg.org/badges/version/remind)](https://cran.r-project.org/package=remind)   [![R build status](https://github.com/pik-piam/remind/workflows/check/badge.svg)](https://github.com/pik-piam/remind/actions) [![codecov](https://codecov.io/gh/pik-piam/remind/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/remind)
 
 ## Purpose and Functionality
 
@@ -46,7 +46,8 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **remind** in publications use:
 
-Giannousakis A, Pehl M (2020). _remind: The REMIND R package_. R package version 36.181.1.
+Giannousakis A, Pehl M (2021). _remind: The REMIND R package_. R package version
+36.182.1.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,8 +55,8 @@ A BibTeX entry for LaTeX users is
 @Manual{,
   title = {remind: The REMIND R package},
   author = {Anastasis Giannousakis and Michaja Pehl},
-  year = {2020},
-  note = {R package version 36.181.1},
+  year = {2021},
+  note = {R package version 36.182.1},
 }
 ```
 


### PR DESCRIPTION
Fixes a bug in the calculation of the energy supply emissions under CCU. CCU CO2 flows need to be added to the energy supply&demand variable as these flows are not represented in vm_emiTeDetail. This increases energy supply emissions which did not take into account synfuel emissions before. 