### PR TITLE
fix energy supply emissions w/ CCU

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind: The REMIND R package",
-  "version": "36.182.0",
+  "version": "36.182.1",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.182.0
-Date: 2021-01-07
+Version: 36.182.1
+Date: 2021-01-12
 Authors@R: as.person(c(
 	   "Anastasis Giannousakis <giannou@pik-potsdam.de> [aut,cre]",
 	   "Michaja Pehl [aut]"))

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # The REMIND R package
 
-R package **remind**, version **36.181.1**
+R package **remind**, version **36.182.1**
 
-  
 
 ## Purpose and Functionality
 
@@ -46,7 +45,8 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **remind** in publications use:
 
-Giannousakis A, Pehl M (2020). _remind: The REMIND R package_. R package version 36.181.1.
+Giannousakis A, Pehl M (2021). _remind: The REMIND R package_. R package version
+36.182.1.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,8 +54,8 @@ A BibTeX entry for LaTeX users is
 @Manual{,
   title = {remind: The REMIND R package},
   author = {Anastasis Giannousakis and Michaja Pehl},
-  year = {2020},
-  note = {R package version 36.181.1},
+  year = {2021},
+  note = {R package version 36.182.1},
 }
 ```
 


### PR DESCRIPTION
This fixes the calculation of energy supply emissions when CCU is on. CO2 flows of CCU were accidentally substracted from energy supply emissions before. Gross non-electric supply emissions should not be negative anymore now. 