### PR TITLE
First automated tests including a template for data integrity checks

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.git$
-^tests/testgdxs/.*\.gdx$
 ^\.buildlibrary$
 ^.*\.zenodo.json$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,6 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.git$
-^inst/extdata/old\.gdx$
+^tests/testgdxs/.*\.gdx$
 ^\.buildlibrary$
 ^.*\.zenodo.json$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6755060277'
+ValidationKey: '6755190960'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind: The REMIND R package",
-  "version": "36.183.3",
+  "version": "36.184.0",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: remind
 Type: Package
-Title: The REMIND R package
+Title: The REMIND R Package
 Version: 36.184.0
 Date: 2021-02-11
-Authors@R: as.person(c(
-	   "Anastasis Giannousakis <giannou@pik-potsdam.de> [aut,cre]",
-	   "Michaja Pehl [aut]"))
+Authors@R: c(
+	person("Anastasis", "Giannousakis", email="giannou@pik-potsdam.de", role=c("aut","cre")),
+	person("Michaja", "Pehl", role=c("aut")))
 Description: Contains the REMIND-specific routines for data and model output manipulation.
 Depends:
     gdx(>= 1.29),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: remind
 Type: Package
 Title: The REMIND R package
-Version: 36.183.3
+Version: 36.184.0
 Date: 2021-02-11
 Authors@R: as.person(c(
 	   "Anastasis Giannousakis <giannou@pik-potsdam.de> [aut,cre]",

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -41,7 +41,13 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
       dir.create(testgdx_folder)
     }
     download.file("https://paste.c-net.org/MasksGallons", file.path(testgdx_folder, "fulldata.gdx"))
+    if(md5sum(file.path(testgdx_folder, "fulldata.gdx")) != "9cbeaee916097d289905982c54fbf1f6"){
+      fail("Checksum for downloaded GDX not correct.")
+    }
     download.file("https://paste.c-net.org/BroaderChevy", file.path(testgdx_folder, "old.gdx"))
+    if(md5sum(file.path(testgdx_folder, "old.gdx")) != "252f9fe2c9a1c9acbbb9ffbca1aeb0f2"){
+      fail("Checksum for downloaded GDX not correct.")
+    }
   }
   my_gdxs <- list.files(testgdx_folder, "*.gdx", full.names = TRUE)
 

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -1,13 +1,53 @@
 context("REMIND reporting")
 
-test_that("Test if REMIND reporting is produced as it should", {
+library(gdx)
+library(data.table)
 
-  library(gdx)
+## Check REMIND output. dt is a data.table in *wide* format,
+## i.e., variables are columns. `eqs` is a list of equations of the form
+## list(LHS = "RHS", ...). The scope determines if the equations
+## should be checked for regions ("regional"), only globally ("world") or
+## both ("all"). Sensitivity determines the allowed offset when comparing
+## LHS to RHS
+check_eqs <- function(dt, eqs, scope="all", sens=1e-10){
+  if(scope == "regional"){
+    dt <- dt[all_regi != "World"]
+  }else if(scope == "world"){
+    dt <- dt[all_regi == "World"]
+  }
+
+  for(LHS in names(eqs)){
+    stopifnot(!(c("total", "diff") %in% unique(dt[["variable"]])))
+    exp <- parse(text=eqs[[LHS]])
+    dt[, total := eval(exp), by=.(all_regi, ttot, scenario, model)]
+
+    dt[, diff := total - get(LHS)]
+    if(nrow(dt[abs(diff) > sens]) > 0){
+      fail(
+        sprintf("Check on data integrity failed for %s", LHS))
+    }
+    ## expect_equal(dt[["total"]], dt[[LHS]], tolerance = sens)
+  }
+
+}
+
+test_that("Test if REMIND reporting is produced as it should and check data integrity", {
 
   ## add GDXs for comparison here:
-  my_gdxs <- c(
-    # system.file('extdata/old.gdx', package = 'remind'),
-    NULL)
+  my_gdxs <- list.files("../testgdxs/", "*.gdx", full.names = TRUE)
+
+  ## please add variable tests below
+  check_integrity <- function(out){
+    dt <- rmndt::magpie2dt(out)
+    dt_wide <- data.table::dcast(dt, ... ~ variable)
+
+    check_eqs(
+      dt_wide,
+      list(
+        `FE|Transport|Liquids (EJ/yr)` = "`FE|Transport|Liquids|Oil (EJ/yr)` + `FE|Transport|Liquids|Biomass (EJ/yr)` + `FE|Transport|Liquids|Hydrogen (EJ/yr)` + `FE|Transport|Liquids|Coal (EJ/yr)`"
+      ))
+
+  }
 
   runParallelTests <- function(gdxs=NULL,cores=0,par=FALSE){
 
@@ -33,18 +73,25 @@ test_that("Test if REMIND reporting is produced as it should", {
       foreach (i = gdxs) %dopar% {
         cat(paste0(i,"\n"))
         a <- convGDX2MIF(i)
+        ## run integrity test only on fulldata
+        if("fulldata.gdx" == basename(i)){
+          print(sprintf("Running integrity test for %s", i))
+          check_integrity(a)
+        }
         cat("\n")
       }
     } else {
       for (i in gdxs) {
         cat(paste0(i,"\n"))
         a <- convGDX2MIF(i)
+        if("fulldata.gdx" == basename(i))
+          check_integrity(a)
         cat("\n")
       }
     }
     unlink(new_gdxs)
   }
 
-  expect_error(runParallelTests(my_gdxs),regexp = NA)
+  runParallelTests(my_gdxs)
 
 })

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -32,8 +32,18 @@ check_eqs <- function(dt, eqs, scope="all", sens=1e-10){
 
 test_that("Test if REMIND reporting is produced as it should and check data integrity", {
 
-  ## add GDXs for comparison here:
-  my_gdxs <- list.files("../testgdxs/", "*.gdx", full.names = TRUE)
+  ## add GDXs for comparison in this folder
+  testgdx_folder <- "../testgdxs/"
+  ## if no GDXs are found, we attempt to download
+  my_gdxs <- list.files(testgdx_folder, "*.gdx", full.names = TRUE)
+  if(length(my_gdxs) == 0){
+    if(!file.exists(testgdx_folder)){
+      dir.create(testgdx_folder)
+    }
+    download.file("https://paste.c-net.org/MasksGallons", file.path(testgdx_folder, "fulldata.gdx"))
+    download.file("https://paste.c-net.org/BroaderChevy", file.path(testgdx_folder, "old.gdx"))
+  }
+  my_gdxs <- list.files(testgdx_folder, "*.gdx", full.names = TRUE)
 
   ## please add variable tests below
   check_integrity <- function(out){

--- a/tests/testthat/test-convGDX2mif.R
+++ b/tests/testthat/test-convGDX2mif.R
@@ -17,7 +17,6 @@ check_eqs <- function(dt, eqs, scope="all", sens=1e-10){
   }
 
   for(LHS in names(eqs)){
-    stopifnot(!(c("total", "diff") %in% unique(dt[["variable"]])))
     exp <- parse(text=eqs[[LHS]])
     dt[, total := eval(exp), by=.(all_regi, ttot, scenario, model)]
 
@@ -39,6 +38,7 @@ test_that("Test if REMIND reporting is produced as it should and check data inte
   ## please add variable tests below
   check_integrity <- function(out){
     dt <- rmndt::magpie2dt(out)
+    stopifnot(!(c("total", "diff") %in% unique(dt[["variable"]])))
     dt_wide <- data.table::dcast(dt, ... ~ variable)
 
     check_eqs(


### PR DESCRIPTION
Integrate a first fully automated test for the call to `convGDX2MIF`. GDXs are shipped in the folder `tests/testgdxs`.


A first data integrity check is performed on the output, by specifying a list of the form
```
list(
        `FE|Transport|Liquids (EJ/yr)` = "`FE|Transport|Liquids|Oil (EJ/yr)` + `FE|Transport|Liquids|Biomass (EJ/yr)` + `FE|Transport|Liquids|Hydrogen (EJ/yr)` + `FE|Transport|Liquids|Coal (EJ/yr)`")
```

This is done by using `data.table` at the moment. For full RSE support, I'd opt for `quitte::calc_addVariables` instead, but there seem to be an issue with `quitte::as.quitte` and I could not successfully convert the magclass object.

This is intended as a first stab and comments & suggestions are welcome!
        
