### PR TITLE
Fix transport pass totals

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6761797515'
+ValidationKey: '6793658650'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind: The REMIND R Package",
-  "version": "36.184.5",
+  "version": "36.184.6",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R Package
-Version: 36.184.5
-Date: 2021-03-01
+Version: 36.184.6
+Date: 2021-05-28
 Authors@R: c(
 	person("Anastasis", "Giannousakis", email="giannou@pik-potsdam.de", role=c("aut","cre")),
 	person("Michaja", "Pehl", role=c("aut")))

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -756,7 +756,7 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
     tmp3 <- mbind(tmp2,
                   setNames(p35_freight_ES_efficiency * tmp2[,,"UE|Transport|Freight (EJ/yr)"],"ES|Transport|Freight (bn tkm/yr)"),
                   setNames(p35_pass_nonLDV_ES_efficiency * tmp2[,,"UE|Transport|Pass|non-LDV (EJ/yr)"],"ES|Transport|Pass|non-LDV (bn pkm/yr)"),
-                  setNames(tmp2[,,"FE|Transport|Pass|non-LDV (EJ/yr)"] + setNames(tmp2[,,"FE|Transport|Pass|Road|LDV (EJ/yr)"],NULL), "FE|Transport|Pass (EJ/yr)")
+                  setNames(tmp2[,,"FE|Transport|Pass|Liquids (EJ/yr)"] + tmp2[,,"FE|Transport|Pass|Hydrogen (EJ/yr)"] + tmp2[,,"FE|Transport|Pass|Electricity (EJ/yr)"], "FE|Transport|Pass (EJ/yr)")
     )
 
     tmp4 <- mbind(tmp3,

--- a/R/reportFE.R
+++ b/R/reportFE.R
@@ -744,8 +744,7 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
 
   if (tran_mod == "complex") {
     tmp2 <- mbind(tmp2a,
-                  setNames(p35_pass_FE_share_transp * tmp1[,, "FE|Transport|non-LDV (EJ/yr)"], "FE|Transport|Pass|non-LDV (EJ/yr)"),
-                  setNames((1- p35_pass_FE_share_transp) * tmp1[,, "FE|Transport|non-LDV (EJ/yr)"], "FE|Transport|Freight (EJ/yr)"),
+                  setNames(tmp1[,, "FE|Transport|Freight|Liquids (EJ/yr)"], "FE|Transport|Freight (EJ/yr)"),
                   setNames(p35_pass_FE_share_transp * tmp1[,, "UE|Transport|HDV (EJ/yr)"], "UE|Transport|Pass|non-LDV (EJ/yr)"),
                   setNames((1- p35_pass_FE_share_transp) * tmp1[,, "UE|Transport|HDV (EJ/yr)"], "UE|Transport|Freight (EJ/yr)"),
                   NULL
@@ -760,7 +759,8 @@ reportFE <- function(gdx,regionSubsetList=NULL) {
     )
 
     tmp4 <- mbind(tmp3,
-                  setNames(tmp3[,,"ES|Transport|Pass|Road|LDV (bn pkm/yr)"] + tmp3[,,"ES|Transport|Pass|non-LDV (bn pkm/yr)"],"ES|Transport|Pass (bn pkm/yr)")
+                  setNames(tmp3[,,"FE|Transport|Pass (EJ/yr)"] - tmp3[,,"FE|Transport|Pass|Road|LDV (EJ/yr)"], "FE|Transport|Pass|non-LDV (EJ/yr)"),
+                  setNames(tmp3[,,"ES|Transport|Pass|Road|LDV (bn pkm/yr)"] + tmp3[,,"ES|Transport|Pass|non-LDV (bn pkm/yr)"], "ES|Transport|Pass (bn pkm/yr)")
     )
   }else{
     # we add no entries here for now. *TODO* check if these entries are used, e.g., in exoGAINSairpollutants, to sum up fes.


### PR DESCRIPTION
`FE|Transport|Pass` was incorrect. It is derived from `FE|Transport|non-LDV` which was wrongly derived from the freight share in liquids, omitting trains.