### PR TITLE
fix 33b766a and include updated v_co2capturevalve values instead of ignoring them

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6821234350'
+ValidationKey: '6827766519'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "remind: The REMIND R Package",
-  "version": "36.185.0",
+  "version": "36.185.1",
   "description": "<p>Contains the REMIND-specific routines for data and model output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: remind
 Type: Package
 Title: The REMIND R Package
-Version: 36.185.0
-Date: 2021-08-12
+Version: 36.185.1
+Date: 2021-08-30
 Authors@R: c(
 	person("Anastasis", "Giannousakis", email="giannou@pik-potsdam.de", role=c("aut","cre")),
 	person("Michaja", "Pehl", role=c("aut")))

--- a/R/reportEmi.R
+++ b/R/reportEmi.R
@@ -756,7 +756,7 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
   tmp2 <- mbind(
     tmp2,
     setNames( 
-      tmp2[,,"Emi|CO2|Carbon Capture and Storage|IndustryCCS|fegas (Mt CO2/yr)"] 
+        tmp2[,,"Emi|CO2|Carbon Capture and Storage|IndustryCCS|fegas (Mt CO2/yr)"] 
       + tmp2[,,"Emi|CO2|Carbon Capture and Storage|IndustryCCS|fesos (Mt CO2/yr)"] 
       + tmp2[,,"Emi|CO2|Carbon Capture and Storage|IndustryCCS|fehos (Mt CO2/yr)"]
       + tmp2[,,'Emi|CO2|Carbon Capture and Storage|IndustryCCS|Process (Mt CO2/yr)'],
@@ -766,7 +766,7 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
   tmp2 <- mbind(
     tmp2,
     setNames( 
-      tmp2[,,"Emi|CO2|Carbon Capture and Storage|IndustryCCS|fegas (Mt CO2/yr)"] 
+        tmp2[,,"Emi|CO2|Carbon Capture and Storage|IndustryCCS|fegas (Mt CO2/yr)"] 
       + tmp2[,,"Emi|CO2|Carbon Capture and Storage|IndustryCCS|fesos (Mt CO2/yr)"] 
       + tmp2[,,"Emi|CO2|Carbon Capture and Storage|IndustryCCS|fehos (Mt CO2/yr)"],
       "Emi|CO2|Carbon Capture and Storage|IndustryCCS|Energy (Mt CO2/yr)")
@@ -778,7 +778,7 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
   # "Carbon Capture|IndustryCCS" and calculate actual 
   # "Carbon Capture and Storage|IndustryCCS" by taking account of carbon 
   # captured, but not sequestered, through v_co2capturevalve
-  mbind(
+  tmp2 <- mbind(
     lapply(
       sub(paste0('^Emi\\|CO2\\|Carbon Capture and Storage\\|IndustryCCS',
                  '(\\|?.*) \\(Mt CO2/yr\\)$'), '\\1', getNames(tmp2)),
@@ -793,7 +793,7 @@ reportEmi <- function(gdx, output=NULL, regionSubsetList=NULL){
       }
     )
   )
-
+  
   tmp <- mbind(tmp, tmp2)
   rm(tmp2)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The REMIND R Package
 
-R package **remind**, version **36.185.0**
+R package **remind**, version **36.185.1**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/remind)](https://cran.r-project.org/package=remind)     [![r-universe](https://pik-piam.r-universe.dev/badges/remind)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/remind)](https://cran.r-project.org/package=remind)    
 
 ## Purpose and Functionality
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **remind** in publications use:
 
-Giannousakis A, Pehl M (2021). _remind: The REMIND R Package_. R package version 36.185.0.
+Giannousakis A, Pehl M (2021). _remind: The REMIND R Package_. R package version 36.185.1.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {remind: The REMIND R Package},
   author = {Anastasis Giannousakis and Michaja Pehl},
   year = {2021},
-  note = {R package version 36.185.0},
+  note = {R package version 36.185.1},
 }
 ```
 


### PR DESCRIPTION
- tests complete without failure
- `lucode2::buildLibrary()` is still confused about the differences between warnings and errors, refuses to update all the fluff file
- I won't clean up the entire package to get it to build